### PR TITLE
Avoid overflow errors with bigger sizes

### DIFF
--- a/app/js/duFromFile.js
+++ b/app/js/duFromFile.js
@@ -135,7 +135,7 @@
         return close()
       }
 
-      let size = 0 | (result[1] * 1024)
+      let size = parseInt(result[1]) * 1024
       let path = result[2].split('/')
 
       // Depending on how find is used the first element may be empty


### PR DESCRIPTION
Apparently the bitwise OR operator (|) in JavaScript
has some integer overflow problems over 32 bits...

This gives the wrong result on "smaller" GB sizes,
and negative results (!) on "bigger" GB sizes.

It was supposed to be logical OR (||), but it is not
needed since the regular expression only allows digits.

Now the results should be accurate up to the highest
integer support reliably by JavaScript, i.e. 53 bits.

Partially reverts 5d711b2e986773041a09a245fca7481794c863c8