### PR TITLE
Update dated node.js version from v6 to v14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '6'
+- '14'
 
 cache: npm
 


### PR DESCRIPTION
node.js v6 is EOL for two years, node.js v14 seem to work well here, should upgrade it.