### PR TITLE
Electrobun Rewrite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,15 @@
 name: Build/release
 
-on: push
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  release:
+  # ---------------------------------------------------------------------------
+  # Electron build (legacy) — macOS, Linux, Windows
+  # ---------------------------------------------------------------------------
+  electron:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 
@@ -24,17 +30,61 @@ jobs:
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1.6.0
         with:
-          # GitHub token, automatically provided to the action
-          # (No need to define this secret in the repo settings)
           github_token: ${{ secrets.github_token }}
-
-          # macOS code signing certificate
           mac_certs: ${{ secrets.MAC_CERTS }}
           mac_certs_password: ${{ secrets.MAC_CERTS_PASSWORD }}
-
-          # If the commit is tagged with a version (e.g. "v1.0.0"),
-          # release the app after building
           release: ${{ startsWith(github.ref, 'refs/tags/v') }}
-
-          # Build only for current platform, explicitly publish
           args: ${{ matrix.os == 'macos-latest' && '--mac --publish always' || matrix.os == 'ubuntu-latest' && '--linux --publish always' || '--win --publish always' }}
+
+  # ---------------------------------------------------------------------------
+  # Electrobun build — macOS ARM64 (Apple Silicon)
+  # ---------------------------------------------------------------------------
+  electrobun-macos-arm64:
+    runs-on: macos-14
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+        working-directory: electrobun
+
+      - name: Determine build environment
+        id: build-env
+        run: |
+          if [[ "${{ github.ref_name }}" == *"-canary"* ]]; then
+            echo "env=canary" >> $GITHUB_OUTPUT
+          else
+            echo "env=stable" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Electrobun app
+        working-directory: electrobun
+        env:
+          ELECTROBUN_DEVELOPER_ID: ${{ secrets.ELECTROBUN_DEVELOPER_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [ "${{ steps.build-env.outputs.env }}" = "canary" ]; then
+            bun run build:canary
+          else
+            bun run build:stable
+          fi
+
+      - name: Upload Electrobun artifacts to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: electrobun/artifacts/*
+          draft: false
+          prerelease: ${{ steps.build-env.outputs.env == 'canary' }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/js/sunburst.js
+++ b/app/js/sunburst.js
@@ -418,6 +418,12 @@ function SunBurst() {
       if (innerR < 0) innerR = 0;
       if (outerR <= innerR) return;
 
+      // Skip arcs too small to draw — their angular span is less than the
+      // 0.005-radian gap subtracted below, which would invert startAngle
+      // and endAngle. The hitTest wrap-around logic then matches nearly
+      // every angle, stealing clicks from real arcs.
+      if (d.dx < 0.005) return;
+
       visibleNodes.push({
         data: d,
         startAngle: d.x + ADJUSTMENT,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -210,6 +210,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "space-radar",
   "productName": "SpaceRadar",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Disk Usage Electron App",
   "author": "Joshua Koo",
   "main": "main.js",

--- a/electrobun/FEATURE-PARITY.md
+++ b/electrobun/FEATURE-PARITY.md
@@ -1,0 +1,143 @@
+# Feature Parity: Electron vs Electrobun
+
+Audit of all features comparing the original Electron version with the Electrobun port.
+
+## Summary
+
+| Category          | Done   | Partial | Missing | Total  |
+| ----------------- | ------ | ------- | ------- | ------ |
+| Scanning          | 10     | 0       | 1       | 11     |
+| Visualization     | 7      | 0       | 1       | 8      |
+| Navigation        | 6      | 0       | 0       | 6      |
+| File Operations   | 2      | 2       | 1       | 5      |
+| Color Schemes     | 17     | 0       | 0       | 17     |
+| Window Management | 2      | 1       | 0       | 3      |
+| Persistence       | 4      | 0       | 0       | 4      |
+| Menu              | 5      | 3       | 1       | 9      |
+| Platform Features | 2      | 2       | 3       | 7      |
+| UI Elements       | 14     | 1       | 1       | 16     |
+| **Total**         | **69** | **9**   | **8**   | **86** |
+
+## 1. Scanning
+
+| Feature              | Electron                                                  | Electrobun                               | Status      | Notes                                                               |
+| -------------------- | --------------------------------------------------------- | ---------------------------------------- | ----------- | ------------------------------------------------------------------- |
+| Directory scan       | Yes (`du.js` via hidden BrowserWindow)                    | Yes (`Scanner` class, in-process)        | Done        |                                                                     |
+| Drive scan (`/`)     | Yes                                                       | Yes                                      | Done        | Both show confirmation first                                        |
+| Memory scan          | Yes (`mem.js` — macOS `ps`/`vm_stat` + systeminformation) | Yes (identical logic ported inline)      | Done        |                                                                     |
+| `.du` file loading   | Yes (`duFromFile.js` — reads `du` output, supports `.gz`) | No                                       | **Missing** | Scanner says "Only directory scanning supported". Button is a stub. |
+| Cancel scan          | Yes                                                       | Yes                                      | Done        |                                                                     |
+| Pause scan           | Yes                                                       | Yes                                      | Done        | Both use promise-based gate                                         |
+| Resume scan          | Yes                                                       | Yes                                      | Done        |                                                                     |
+| Progress reporting   | Yes (every 10k items)                                     | Yes (every 10k items)                    | Done        |                                                                     |
+| Live preview refresh | Yes (`TaskChecker` — 5s start, 3x backoff)                | Yes (`RefreshScheduler` — same schedule) | Done        |                                                                     |
+| Exclude paths        | Yes (cloud storage + macOS system)                        | Yes (identical list)                     | Done        |                                                                     |
+| Hardlink dedup       | Yes (`dev:ino` key)                                       | Yes (identical)                          | Done        |                                                                     |
+
+## 2. Visualization
+
+| Feature                   | Electron                  | Electrobun             | Status      | Notes                                                          |
+| ------------------------- | ------------------------- | ---------------------- | ----------- | -------------------------------------------------------------- |
+| Sunburst chart            | Yes (Canvas)              | Yes (Canvas)           | Done        | Full port with animation, hit-testing, center display          |
+| Treemap                   | Yes (Canvas, FakeSVG)     | Yes (identical)        | Done        |                                                                |
+| Flamegraph                | Yes (`d3-flame-graph`)    | Yes (`d3-flame-graph`) | Done        |                                                                |
+| List/sidebar view         | Yes (top 10, sorted)      | Yes (identical)        | Done        |                                                                |
+| Breadcrumb navigation     | Yes (D3 data-join)        | Yes (identical)        | Done        |                                                                |
+| 3D mode (Three.js)        | Yes (`sunburst3d.js`)     | No                     | **Missing** | Canvas element exists, menu item exists, but no Three.js code. |
+| "Other files" aggregation | Yes (0.1% threshold)      | Yes (identical)        | Done        |                                                                |
+| Free space visualization  | Yes (`_isFreeSpace` node) | Yes (identical)        | Done        |                                                                |
+
+## 3. Navigation
+
+| Feature                      | Electron                     | Electrobun      | Status | Notes                    |
+| ---------------------------- | ---------------------------- | --------------- | ------ | ------------------------ |
+| Drill-down (click)           | Yes                          | Yes             | Done   | All chart types          |
+| Navigate up                  | Yes                          | Yes             | Done   | Center-click in sunburst |
+| Back/forward history         | Yes (`NavigationController`) | Yes (identical) | Done   |                          |
+| Zoom in (show more levels)   | Yes                          | Yes             | Done   |                          |
+| Zoom out (show fewer levels) | Yes                          | Yes             | Done   |                          |
+| Breadcrumb path click        | Yes                          | Yes             | Done   |                          |
+
+## 4. File Operations
+
+| Feature            | Electron                             | Electrobun                     | Status      | Notes                                  |
+| ------------------ | ------------------------------------ | ------------------------------ | ----------- | -------------------------------------- |
+| Show in Finder     | Yes (`shell.showItemInFolder`)       | Yes (`Utils.showItemInFolder`) | Done        |                                        |
+| Move to trash      | Yes (`shell.moveItemToTrash` + beep) | Yes (`Utils.moveToTrash`)      | Partial     | Missing `shell.beep()` on success      |
+| Open file directly | Yes (`shell.openItem`)               | No — uses `showItemInFolder`   | Partial     | `openSelection()` falls back to Finder |
+| Context menu       | Yes (`remote.Menu`)                  | Yes (`ContextMenu`)            | Done        | Same 3 items                           |
+| External open      | Yes (`shell.openExternal`)           | No                             | **Missing** | Low priority — not in context menu     |
+
+## 5. Color Schemes
+
+All 17 color features are fully ported: 6 Seaborn palettes, 3 legacy schemes, 6 color modes, dark mode, localStorage persistence. **All Done.**
+
+## 6. Window Management
+
+| Feature                     | Electron                  | Electrobun | Status  | Notes                                               |
+| --------------------------- | ------------------------- | ---------- | ------- | --------------------------------------------------- |
+| Multiple windows            | Yes                       | Yes        | Done    |                                                     |
+| Window title updates        | Neither version does this | N/A        | Done    |                                                     |
+| Drag to scan (drop folders) | Yes (`file.path`)         | Partial    | Partial | `file.path` may not be available in WebView sandbox |
+
+## 7. Persistence
+
+All 4 persistence features are fully ported: save scan data, load last scan, "Last loaded" button, auto-show prompt on startup. **All Done.**
+
+## 8. Menu
+
+| Feature            | Electron                     | Electrobun                         | Status      | Notes                          |
+| ------------------ | ---------------------------- | ---------------------------------- | ----------- | ------------------------------ |
+| macOS App menu     | Yes                          | Yes                                | Done        |                                |
+| Edit menu          | Yes (+ Speech)               | Yes (no Speech submenu)            | Partial     | Minor                          |
+| View menu          | Yes                          | Yes                                | Done        |                                |
+| Window menu        | Yes (+ "Bring All to Front") | Yes (no "Front")                   | Partial     | Minor                          |
+| Help menu          | Yes                          | Yes                                | Done        |                                |
+| Color Options menu | Yes (radio/checkbox items)   | Yes (action items, no check state) | Partial     | No visual radio/check feedback |
+| Auto-updater       | Yes (`electron-updater`)     | No                                 | **Missing** |                                |
+
+## 9. Platform Features
+
+| Feature               | Electron                | Electrobun                | Status      | Notes                       |
+| --------------------- | ----------------------- | ------------------------- | ----------- | --------------------------- |
+| macOS traffic lights  | Yes (`hidden`)          | Yes (`hiddenInset`)       | Done        |                             |
+| Dynamic window sizing | Yes (80% screen height) | Fixed 1200x800 + centered | Partial     | Could compute from workArea |
+| `acceptFirstMouse`    | Yes                     | Not set                   | **Missing** | Minor UX                    |
+| Windows/Linux support | Yes                     | macOS only                | **Missing** | Electrobun limitation       |
+| Expose GC             | Yes (`--expose_gc`)     | No                        | **Missing** | Minor                       |
+
+## 10. UI Elements
+
+| Feature                            | Electron                         | Electrobun                                | Status      | Notes                                             |
+| ---------------------------------- | -------------------------------- | ----------------------------------------- | ----------- | ------------------------------------------------- |
+| Toolbar buttons (all)              | Yes                              | Yes                                       | Done        | Open, Scan Drive/Folder, DU file, Memory, +/-, Up |
+| Mode buttons (sunburst/flame/tree) | Yes                              | Yes                                       | Done        |                                                   |
+| Footer: back/forward               | Yes                              | Yes                                       | Done        |                                                   |
+| Footer: disk space info            | Yes                              | Yes                                       | Done        |                                                   |
+| Footer: status bar                 | Yes                              | Yes                                       | Done        |                                                   |
+| Footer: Locate Directory           | Yes                              | Yes                                       | Done        |                                                   |
+| Footer: Cancel/Pause Scan          | Yes                              | Yes                                       | Done        |                                                   |
+| Legend overlay                     | Yes                              | Yes                                       | Done        |                                                   |
+| Loading overlay                    | Yes                              | Yes                                       | Done        |                                                   |
+| Prompt box                         | Yes                              | Yes                                       | Done        |                                                   |
+| Load DU file button                | Yes (functional)                 | Stub (calls scanFolder)                   | Partial     |                                                   |
+| Memory poller                      | Yes (periodic re-scan)           | No (one-shot only)                        | **Missing** |                                                   |
+| Toolbar drag to move window        | Yes (`-webkit-app-region: drag`) | Yes (`electrobun-webkit-app-region-drag`) | Done        |                                                   |
+
+## Key Missing Features (by impact)
+
+1. **`.du` file loading** — Backend not implemented. Button is a stub.
+2. **3D mode (Three.js)** — No Three.js code ported. Menu item is a no-op.
+3. **Windows/Linux support** — Electrobun is macOS-only.
+4. **Auto-updater** — No equivalent to `electron-updater`.
+5. **Memory polling** — One-shot works; periodic re-scan missing.
+
+## Architecture Differences
+
+| Aspect          | Electron                                                          | Electrobun                                 |
+| --------------- | ----------------------------------------------------------------- | ------------------------------------------ |
+| IPC             | 4 mechanisms (ipcMain, localStorage, temp file, webContents.send) | Unified typed RPC over encrypted WebSocket |
+| Scanner process | Hidden BrowserWindow                                              | Bun main process (in-process async)        |
+| Bundling        | 20+ separate `<script>` tags                                      | Single bundled `index.js` via Bun          |
+| D3 version      | d3 v3 + modules via CommonJS                                      | d3 v3 + modules via ESM                    |
+| UI framework    | PhotonKit CSS                                                     | Self-contained PhotonKit-compatible CSS    |

--- a/electrobun/SCANNER-ARCHITECTURE.md
+++ b/electrobun/SCANNER-ARCHITECTURE.md
@@ -1,0 +1,84 @@
+# Scanner Architecture Options
+
+## Context
+
+The filesystem scanner needs to run without blocking the main Bun process
+(which handles RPC, menu events, and UI callbacks). The original approach used
+a Bun `Worker` thread, but `postMessage` across the thread boundary suffers
+from a data-corruption bug in Electrobun v1.13.1: the native FFI's
+`threadsafe` callbacks receive dangling C-string pointers because the
+underlying NSString is freed by ARC before the JavaScript thread reads the
+data. See the GitHub issue filed against Electrobun for details.
+
+## Options
+
+### Option A: In-process scanner (current choice)
+
+Run `Scanner` directly in the main Bun process. The scanner is fully
+async (`await lstat()` / `await readdir()` on every entry), so it
+naturally yields to the event loop between filesystem operations.
+
+**Mitigations for UI lockup:**
+
+- Explicit `setTimeout(0)` yield every N items (e.g., every 1 000 entries)
+  to guarantee the event loop can drain RPC and menu events.
+- `JSON.stringify` for `onRefresh` / `onComplete` is the only CPU-heavy
+  moment; refresh frequency is exponentially backed off so this runs
+  rarely (5 s, 15 s, 45 s, ...).
+
+**Pros:**
+
+- Zero IPC, no serialization for scanner → bun (tree stays in memory)
+- No thread boundary, no FFI cstring corruption
+- Simplest code; scanner-worker.ts becomes unused
+- Cancel / pause / resume are direct method calls
+
+**Cons:**
+
+- Shares the event loop with RPC; a very large `JSON.stringify` can
+  cause a brief micro-pause (~10-50 ms for million-node trees)
+
+### Option B: Child process with stdio IPC
+
+Spawn a separate `Bun` process (`Bun.spawn`) running the scanner as a
+standalone script. Communicate via newline-delimited JSON on stdin/stdout.
+
+**Pros:**
+
+- True process isolation (crash isolation, separate memory, separate GC)
+- stdio is a byte stream — no FFI cstring issues
+- Could scan as root / with different permissions
+
+**Cons:**
+
+- Still needs `JSON.stringify` / `JSON.parse` for every message
+- More complex lifecycle management (spawn, kill, restart)
+- Slightly higher latency than in-process calls
+- Need to bundle or copy the scanner script separately
+
+### Option C: Worker with WebSocket IPC
+
+Keep the Worker thread but bypass `postMessage`. Instead, the Worker
+connects to a local WebSocket server (similar to how the browser RPC works).
+
+**Pros:**
+
+- True thread isolation with reliable string transport
+- WebSocket handles framing and buffering
+
+**Cons:**
+
+- Over-engineered for inter-thread communication
+- Adds network stack overhead for something that should be memory-to-memory
+- Complexity of managing the WebSocket lifecycle inside a Worker
+
+## Decision
+
+**Option A** was selected. The scanner's fully-async design means every
+filesystem call yields to the event loop. The only CPU-bound moment is
+`JSON.stringify` for refresh previews, which is mitigated by exponential
+backoff (fires rarely). An explicit yield every 1 000 entries provides an
+additional safety margin.
+
+If Option A proves insufficient for extremely large scans (tens of millions
+of files), Option B (child process) is the recommended escalation path.

--- a/electrobun/electrobun.config.ts
+++ b/electrobun/electrobun.config.ts
@@ -1,0 +1,23 @@
+export default {
+  app: {
+    name: "Space Radar",
+    identifier: "com.zz85.spaceradar",
+    version: "7.0.0",
+  },
+  build: {
+    bun: {
+      entrypoint: "src/bun/index.ts",
+      external: [],
+    },
+    views: {
+      mainview: {
+        entrypoint: "src/mainview/index.ts",
+        external: [],
+      },
+    },
+    copy: {
+      "src/mainview/index.html": "views/mainview/index.html",
+      "src/mainview/style.css": "views/mainview/style.css",
+    },
+  },
+};

--- a/electrobun/electrobun.config.ts
+++ b/electrobun/electrobun.config.ts
@@ -20,4 +20,7 @@ export default {
       "src/mainview/style.css": "views/mainview/style.css",
     },
   },
+  release: {
+    baseUrl: "https://github.com/zz85/space-radar/releases/latest/download",
+  },
 };

--- a/electrobun/package.json
+++ b/electrobun/package.json
@@ -10,16 +10,16 @@
     "build:release": "electrobun build --release"
   },
   "dependencies": {
-    "electrobun": "^0.8.0",
     "d3": "^3.5.17",
-    "d3-hierarchy": "^1.1.9",
-    "d3-scale": "^1.0.7",
-    "d3-selection": "^1.4.2",
-    "d3-tip": "^0.9.1",
     "d3-ease": "^1.0.7",
     "d3-flame-graph": "4.1.3",
-    "d3-shape": "^0.6.1",
+    "d3-hierarchy": "^1.1.9",
     "d3-path": "^1.0.9",
+    "d3-scale": "^1.0.7",
+    "d3-selection": "^1.4.2",
+    "d3-shape": "^0.6.1",
+    "d3-tip": "^0.9.1",
+    "electrobun": "^1.13.1",
     "systeminformation": "^5.30.7",
     "three": "^0.160.0"
   },

--- a/electrobun/package.json
+++ b/electrobun/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "space-radar-electrobun",
+  "version": "7.0.0",
+  "description": "Disk Usage Visualization App - Electrobun Edition",
+  "author": "Joshua Koo",
+  "license": "MIT",
+  "scripts": {
+    "start": "bun run build:dev && electrobun dev",
+    "build:dev": "bun install && electrobun build",
+    "build:release": "electrobun build --release"
+  },
+  "dependencies": {
+    "electrobun": "^0.8.0",
+    "d3": "^3.5.17",
+    "d3-hierarchy": "^1.1.9",
+    "d3-scale": "^1.0.7",
+    "d3-selection": "^1.4.2",
+    "d3-tip": "^0.9.1",
+    "d3-ease": "^1.0.7",
+    "d3-flame-graph": "4.1.3",
+    "d3-shape": "^0.6.1",
+    "d3-path": "^1.0.9",
+    "systeminformation": "^5.30.7",
+    "three": "^0.160.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/d3": "^3.5.38",
+    "typescript": "^5.7.0"
+  }
+}

--- a/electrobun/package.json
+++ b/electrobun/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "bun run build:dev && electrobun dev",
     "build:dev": "bun install && electrobun build",
-    "build:release": "electrobun build --release"
+    "build:canary": "electrobun build --env=canary",
+    "build:stable": "electrobun build --env=stable"
   },
   "dependencies": {
     "d3": "^3.5.17",

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -213,9 +213,11 @@ function combineMemory(
 }
 
 async function scanMemoryMac(): Promise<any> {
-  const { stdout: vmStatOut } = await execAsync(MAC_VM_STAT);
+  const [{ stdout: vmStatOut }, { stdout: psOut }] = await Promise.all([
+    execAsync(MAC_VM_STAT),
+    execAsync(MAC_PS_CMD),
+  ]);
   const vmStat = parseVmStat(vmStatOut);
-  const { stdout: psOut } = await execAsync(MAC_PS_CMD);
   const processInfo = parseProcesses(psOut);
   return combineMemory(processInfo, vmStat);
 }

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -1,0 +1,707 @@
+/**
+ * Space Radar - Electrobun Main Process Entry Point
+ *
+ * Creates the main BrowserWindow, sets up the application menu with color
+ * options, and wires all RPC handlers for scanning, file operations, memory
+ * profiling, and persistence.
+ */
+
+import Electrobun, {
+  BrowserWindow,
+  BrowserView,
+  ApplicationMenu,
+  ContextMenu,
+  Utils,
+} from "electrobun/bun";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { deflateSync, inflateSync } from "node:zlib";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+import { Scanner } from "./scanner";
+import type { SpaceRadarRPC } from "../shared/types";
+
+const execAsync = promisify(exec);
+
+// ---------------------------------------------------------------------------
+// Platform helpers
+// ---------------------------------------------------------------------------
+
+const isMac = process.platform === "darwin";
+const isWindows = process.platform === "win32";
+
+function getAppDataDir(): string {
+  const home = homedir();
+  if (isMac) return join(home, "Library", "Application Support", "SpaceRadar");
+  if (isWindows)
+    return join(
+      process.env.APPDATA || join(home, "AppData", "Roaming"),
+      "SpaceRadar",
+    );
+  return join(home, ".config", "SpaceRadar");
+}
+
+function ensureAppDataDir(): string {
+  const dir = getAppDataDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+const LAST_SCAN_FILE = "lastload.json.z";
+
+// ---------------------------------------------------------------------------
+// Active scanner instance (one per app for now)
+// ---------------------------------------------------------------------------
+
+let activeScanner: Scanner | null = null;
+
+// ---------------------------------------------------------------------------
+// Memory scanning (port of app/js/mem.js)
+// ---------------------------------------------------------------------------
+
+const MAC_PS_CMD = "ps -cx -opid,ppid,rss,comm";
+const MAC_VM_STAT = "vm_stat";
+
+interface ProcessInfo {
+  pid: number;
+  ppid: number;
+  rss: number;
+  comm: string;
+  name?: string;
+  size?: number;
+  children?: any[];
+  parent?: number;
+}
+
+function parseVmStat(out: string): Record<string, number> {
+  const pageSizeMatch = /page size of (\d+)/.exec(out);
+  const pageSize = pageSizeMatch ? +pageSizeMatch[1] : 4096;
+
+  const vmStat: Record<string, number> = {};
+  const pageReg = /Pages\s+([^:]+)[^\d]+(\d+)/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = pageReg.exec(out))) {
+    vmStat[m[1]] = +m[2] * pageSize;
+  }
+
+  return vmStat;
+}
+
+function parseProcesses(stdout: string): {
+  app: any;
+  sum: number;
+  count: number;
+} {
+  const regex = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/gm;
+  let m: RegExpExecArray | null;
+
+  let count = 0;
+  let rssSum = 0;
+  const all: Record<number, ProcessInfo> = {};
+
+  while ((m = regex.exec(stdout))) {
+    const pid = +m[1];
+    const ppid = +m[2];
+    const rss = +m[3] * 1024;
+    const comm = m[4];
+
+    count++;
+    rssSum += rss;
+    all[pid] = { pid, ppid, rss, comm };
+  }
+
+  const app: any = { name: "App Memory", children: [] };
+
+  Object.keys(all)
+    .map((k) => all[+k])
+    .sort((a, b) => a.pid - b.pid)
+    .forEach((a) => {
+      let parent: any;
+      if (a.ppid in all) {
+        parent = all[a.ppid];
+      } else {
+        parent = app;
+      }
+
+      if (!parent.children) {
+        parent.children = [];
+        parent.children.push({
+          name: parent.name,
+          size: parent.rss,
+          parent: 1,
+        });
+        delete parent.size;
+      }
+      parent.children.push(a);
+
+      a.name = `${a.comm} (${a.pid})`;
+      a.size = a.rss;
+      delete (a as any).comm;
+      delete (a as any).pid;
+      delete (a as any).rss;
+      delete (a as any).ppid;
+    });
+
+  return { app, sum: rssSum, count };
+}
+
+function combineMemory(
+  processInfo: { app: any; sum: number; count: number },
+  vmStat: Record<string, number>,
+): any {
+  const top: any = { name: "Memory", children: [] };
+
+  const diff = (vmStat.active || 0) - processInfo.sum;
+  const active: any = { name: "Active Memory", children: [processInfo.app] };
+  top.children.push(active);
+
+  if (diff > 0) {
+    active.children.push({ name: "Kernel / others", size: diff });
+  }
+
+  for (const n of [
+    "free",
+    "inactive",
+    "speculative",
+    "wired down",
+    "occupied by compressor",
+  ]) {
+    if (vmStat[n] > 0) {
+      top.children.push({ name: n, size: vmStat[n] });
+    }
+  }
+
+  return top;
+}
+
+async function scanMemoryMac(): Promise<any> {
+  const { stdout: vmStatOut } = await execAsync(MAC_VM_STAT);
+  const vmStat = parseVmStat(vmStatOut);
+  const { stdout: psOut } = await execAsync(MAC_PS_CMD);
+  const processInfo = parseProcesses(psOut);
+  return combineMemory(processInfo, vmStat);
+}
+
+async function scanMemorySysteminfo(): Promise<any> {
+  try {
+    const si = await import("systeminformation");
+    const [memData, processData] = await Promise.all([
+      si.mem(),
+      si.processes(),
+    ]);
+
+    const memInfo: Record<string, number> = {
+      free: memData.free || 0,
+      active: memData.active || memData.used || 0,
+      inactive: (memData as any).inactive || 0,
+      speculative: (memData as any).speculative || 0,
+      "wired down": (memData as any).wired || 0,
+      "occupied by compressor": (memData as any).compressed || 0,
+    };
+
+    const all: Record<number, ProcessInfo> = {};
+    let count = 0;
+    let rssSum = 0;
+
+    for (const proc of processData.list) {
+      const pid = proc.pid;
+      const ppid = proc.parentPid;
+      const rss = (proc.memRss || 0) * 1024;
+      const comm = proc.name || "Unknown";
+
+      if (pid === 0) continue;
+
+      count++;
+      rssSum += rss;
+      all[pid] = { pid, ppid, rss, comm };
+    }
+
+    const app: any = { name: "App Memory", children: [] };
+
+    Object.keys(all)
+      .map((k) => all[+k])
+      .sort((a, b) => a.pid - b.pid)
+      .forEach((a) => {
+        let parent: any;
+        if (a.ppid in all) {
+          parent = all[a.ppid];
+        } else {
+          parent = app;
+        }
+
+        if (!parent.children) {
+          parent.children = [];
+          parent.children.push({
+            name: parent.name,
+            size: parent.rss,
+            parent: 1,
+          });
+          delete parent.size;
+        }
+        parent.children.push(a);
+
+        a.name = `${a.comm} (${a.pid})`;
+        a.size = a.rss;
+        delete (a as any).comm;
+        delete (a as any).pid;
+        delete (a as any).rss;
+        delete (a as any).ppid;
+      });
+
+    const processInfo = { app, sum: rssSum, count };
+    return combineMemory(processInfo, memInfo);
+  } catch (err) {
+    console.error("[scanMemory] systeminformation error:", err);
+    return null;
+  }
+}
+
+async function scanMemory(): Promise<any> {
+  if (isMac) {
+    return scanMemoryMac();
+  }
+  return scanMemorySysteminfo();
+}
+
+// ---------------------------------------------------------------------------
+// Track the most recently created window for menu routing
+// ---------------------------------------------------------------------------
+
+let latestWindow: BrowserWindow<any> | null = null;
+
+// ---------------------------------------------------------------------------
+// Window creation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a new BrowserWindow with its own RPC instance.
+ *
+ * The RPC handlers capture `windowRef` via closure so that scanner callbacks
+ * and menu events route to the correct window. We use a mutable ref object
+ * so the RPC definition can be created before the window exists, then the
+ * window is immediately assigned into the ref.
+ */
+function createAppWindow(): BrowserWindow<any> {
+  // Mutable ref so RPC handlers can reach the window they belong to
+  const windowRef: { current: BrowserWindow<any> | null } = { current: null };
+
+  const rpc = BrowserView.defineRPC<SpaceRadarRPC>({
+    maxRequestTime: 300_000, // 5 minutes for long scans
+    handlers: {
+      requests: {
+        selectFolder: async ({ startingFolder }) => {
+          try {
+            const result = await Utils.openFileDialog({
+              startingFolder: startingFolder || homedir(),
+              canChooseFiles: false,
+              canChooseDirectory: true,
+              allowsMultipleSelection: false,
+            });
+            const filtered = result.filter((p: string) => p.trim() !== "");
+            return filtered.length > 0 ? filtered[0] : null;
+          } catch (err) {
+            console.error("[selectFolder] error:", err);
+            return null;
+          }
+        },
+
+        scanDirectory: async ({ path: targetPath }) => {
+          try {
+            // Cancel any existing scan
+            if (activeScanner) {
+              activeScanner.cancel();
+            }
+
+            const targetWin = windowRef.current;
+
+            activeScanner = new Scanner({
+              onProgress: (
+                dir,
+                name,
+                size,
+                fileCount,
+                dirCount,
+                errorCount,
+              ) => {
+                targetWin?.webview.rpc?.send.scanProgress({
+                  dir,
+                  name,
+                  size,
+                  fileCount,
+                  dirCount,
+                  errorCount,
+                });
+              },
+              onRefresh: (tree) => {
+                targetWin?.webview.rpc?.send.scanRefresh({
+                  data: JSON.stringify(tree),
+                });
+              },
+              onComplete: (tree, stats) => {
+                targetWin?.webview.rpc?.send.scanComplete({
+                  data: JSON.stringify(tree),
+                  stats: {
+                    fileCount: stats.fileCount,
+                    dirCount: stats.dirCount,
+                    currentSize: stats.currentSize,
+                    errorCount: stats.errorCount,
+                    cancelled: stats.cancelled,
+                  },
+                });
+              },
+              onError: (error) => {
+                targetWin?.webview.rpc?.send.scanError({ error });
+              },
+            });
+
+            // Start scan in background (don't await - it runs asynchronously)
+            activeScanner.scan(targetPath);
+
+            return { started: true };
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error("[scanDirectory] error:", msg);
+            return { started: false, error: msg };
+          }
+        },
+
+        cancelScan: async () => {
+          if (activeScanner) {
+            activeScanner.cancel();
+          }
+        },
+
+        pauseScan: async () => {
+          if (activeScanner) {
+            activeScanner.pause();
+          }
+        },
+
+        resumeScan: async () => {
+          if (activeScanner) {
+            activeScanner.resume();
+          }
+        },
+
+        showItemInFolder: async ({ path: itemPath }) => {
+          try {
+            await Utils.showItemInFolder(itemPath);
+          } catch (err) {
+            console.error("[showItemInFolder] error:", err);
+          }
+        },
+
+        moveToTrash: async ({ path: itemPath }) => {
+          try {
+            await Utils.moveToTrash(itemPath);
+            return true;
+          } catch (err) {
+            console.error("[moveToTrash] error:", err);
+            return false;
+          }
+        },
+
+        openNewWindow: async () => {
+          createAppWindow();
+        },
+
+        getDiskInfo: async ({ path: diskPath }) => {
+          try {
+            const si = await import("systeminformation");
+            const fsData = await si.fsSize();
+
+            // Find the filesystem that contains this path
+            // Sort by mount point length (longest first) to find most specific match
+            const sorted = [...fsData].sort(
+              (a, b) => b.mount.length - a.mount.length,
+            );
+
+            for (const entry of sorted) {
+              if (diskPath.startsWith(entry.mount)) {
+                return {
+                  total: entry.size,
+                  used: entry.used,
+                  available: entry.available,
+                  usePercent: entry.use,
+                };
+              }
+            }
+
+            // Fallback to root mount
+            const root = fsData.find((entry) => entry.mount === "/");
+            if (root) {
+              return {
+                total: root.size,
+                used: root.used,
+                available: root.available,
+                usePercent: root.use,
+              };
+            }
+
+            return null;
+          } catch (err) {
+            console.error("[getDiskInfo] error:", err);
+            return null;
+          }
+        },
+
+        loadLastScan: async () => {
+          try {
+            const dataDir = ensureAppDataDir();
+            const filePath = join(dataDir, LAST_SCAN_FILE);
+
+            if (!existsSync(filePath)) {
+              return null;
+            }
+
+            const compressed = readFileSync(filePath);
+            const decompressed = inflateSync(compressed);
+            return decompressed.toString("utf-8");
+          } catch (err) {
+            console.error("[loadLastScan] error:", err);
+            return null;
+          }
+        },
+
+        saveScanData: async ({ data }) => {
+          try {
+            const dataDir = ensureAppDataDir();
+            const filePath = join(dataDir, LAST_SCAN_FILE);
+            const compressed = deflateSync(Buffer.from(data, "utf-8"));
+            writeFileSync(filePath, compressed);
+            console.log(
+              `[saveScanData] Saved ${data.length} bytes -> ${compressed.length} bytes compressed`,
+            );
+          } catch (err) {
+            console.error("[saveScanData] error:", err);
+          }
+        },
+
+        showContextMenu: async ({ items }) => {
+          ContextMenu.showContextMenu(
+            items.map((item) => ({
+              label: item.label,
+              action: item.action,
+              enabled: item.enabled !== false,
+            })),
+          );
+        },
+
+        scanMemory: async () => {
+          try {
+            const tree = await scanMemory();
+            return tree ? JSON.stringify(tree) : null;
+          } catch (err) {
+            console.error("[scanMemory] error:", err);
+            return null;
+          }
+        },
+      },
+      messages: {
+        logToBun: ({ msg }) => {
+          console.log("[webview]", msg);
+        },
+      },
+    },
+  });
+
+  const newWin = new BrowserWindow({
+    title: "Space Radar",
+    url: "views://mainview/index.html",
+    frame: {
+      width: 1200,
+      height: 900,
+      x: 100,
+      y: 100,
+    },
+    titleBarStyle: "hiddenInset",
+    rpc,
+  });
+
+  // Wire up the ref so RPC handlers can reach this window
+  windowRef.current = newWin;
+
+  // Track the latest window for menu events
+  latestWindow = newWin;
+
+  newWin.on("close", () => {
+    process.exit(0);
+  });
+
+  return newWin;
+}
+
+// ---------------------------------------------------------------------------
+// Application Menu
+// ---------------------------------------------------------------------------
+
+ApplicationMenu.setApplicationMenu([
+  // macOS app menu (first slot is the app name menu on macOS)
+  {
+    submenu: [
+      { label: "About Space Radar", role: "about" },
+      { type: "separator" },
+      { label: "Hide Space Radar", role: "hide", accelerator: "Command+H" },
+      {
+        label: "Hide Others",
+        role: "hideOthers",
+        accelerator: "Command+Shift+H",
+      },
+      { label: "Show All", role: "unhide" },
+      { type: "separator" },
+      { label: "Quit Space Radar", role: "quit", accelerator: "Command+Q" },
+    ],
+  },
+  {
+    label: "Edit",
+    submenu: [
+      { role: "undo" },
+      { role: "redo" },
+      { type: "separator" },
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      { role: "selectAll" },
+    ],
+  },
+  {
+    label: "View",
+    submenu: [
+      { role: "reload" },
+      { role: "forceReload" },
+      { role: "toggleDevTools" },
+      { type: "separator" },
+      { role: "resetZoom" },
+      { role: "zoomIn" },
+      { role: "zoomOut" },
+      { type: "separator" },
+      { role: "togglefullscreen" },
+    ],
+  },
+  {
+    label: "Window",
+    submenu: [
+      { role: "close" },
+      { role: "minimize" },
+      { label: "Zoom", role: "zoom" },
+    ],
+  },
+  {
+    label: "Help",
+    submenu: [
+      {
+        label: "Learn More",
+        action: "help-learn-more",
+      },
+    ],
+  },
+  {
+    label: "Color Options",
+    submenu: [
+      // Seaborn Palettes
+      {
+        label: "Seaborn Palettes",
+        submenu: [
+          { label: "Deep", action: "scheme:seabornDeep" },
+          { label: "Muted", action: "scheme:seabornMuted" },
+          { label: "Pastel (Default)", action: "scheme:seabornPastel" },
+          { label: "Bright", action: "scheme:seabornBright" },
+          { label: "Dark", action: "scheme:seabornDark" },
+          { label: "Colorblind-friendly", action: "scheme:seabornColorblind" },
+        ],
+      },
+      { type: "separator" },
+      // Legacy Schemes
+      {
+        label: "Legacy Schemes",
+        submenu: [
+          { label: "Classic - 11 Categories", action: "scheme:schemeCat11" },
+          { label: "Classic - 6 Categories", action: "scheme:schemeCat6" },
+          { label: "Rainbow (Hash-based)", action: "scheme:schemeHue" },
+        ],
+      },
+      { type: "separator" },
+      // Color Modes
+      {
+        label: "Color Modes",
+        submenu: [
+          { label: "By File Type", action: "mode:colorByProp" },
+          { label: "By Size (Color Gradient)", action: "mode:colorBySize" },
+          { label: "By Size (Greyscale)", action: "mode:colorBySizeBw" },
+          {
+            label: "By Root Directory (Default)",
+            action: "mode:colorByParent",
+          },
+          { label: "By Parent Name", action: "mode:colorByParentName" },
+          { label: "Random / Confetti", action: "mode:colorByRandom" },
+        ],
+      },
+      { type: "separator" },
+      { label: "Dark Mode", action: "toggle:darkMode" },
+      { label: "3D Mode (Experimental)", action: "toggle:3dMode" },
+    ],
+  },
+]);
+
+// ---------------------------------------------------------------------------
+// Handle application menu events
+// ---------------------------------------------------------------------------
+
+Electrobun.events.on("application-menu-clicked", (e) => {
+  const action = e.data.action;
+
+  // Help menu
+  if (action === "help-learn-more") {
+    exec(`open "https://github.com/zz85/space-radar"`);
+    return;
+  }
+
+  // Color scheme changes: action format is "scheme:<value>"
+  if (action.startsWith("scheme:")) {
+    const value = action.slice("scheme:".length);
+    latestWindow?.webview.rpc?.send.colorChange({ type: "scheme", value });
+    return;
+  }
+
+  // Color mode changes: action format is "mode:<value>"
+  if (action.startsWith("mode:")) {
+    const value = action.slice("mode:".length);
+    latestWindow?.webview.rpc?.send.colorChange({ type: "mode", value });
+    return;
+  }
+
+  // Toggle actions: action format is "toggle:<property>"
+  if (action.startsWith("toggle:")) {
+    const property = action.slice("toggle:".length);
+    latestWindow?.webview.rpc?.send.colorChange({
+      type: property,
+      value: "toggle",
+    });
+    return;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Handle context menu events
+// ---------------------------------------------------------------------------
+
+Electrobun.events.on("context-menu-clicked", (e) => {
+  latestWindow?.webview.rpc?.send.contextMenuClicked({
+    action: e.data.action,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create the main window
+// ---------------------------------------------------------------------------
+
+const win = createAppWindow();
+
+console.log("[main] Space Radar started");
+console.log(`[main] Platform: ${process.platform} ${process.arch}`);
+console.log(`[main] App data: ${getAppDataDir()}`);

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -403,9 +403,11 @@ function createAppWindow(): BrowserWindow<any> {
 
               db.scan(targetPath).catch((err) => {
                 console.error("[scanDirectory] unhandled scan error:", err);
-                targetWin?.webview.rpc?.send.scanError({
-                  error: err instanceof Error ? err.message : String(err),
-                });
+                try {
+                  targetWin?.webview.rpc?.send.scanError({
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                } catch (_) {}
               });
             } else {
               // ----- In-memory tree scanner (original approach) -----
@@ -471,9 +473,11 @@ function createAppWindow(): BrowserWindow<any> {
 
               activeInMemoryScanner.scan(targetPath).catch((err) => {
                 console.error("[scanDirectory] unhandled scan error:", err);
-                targetWin?.webview.rpc?.send.scanError({
-                  error: err instanceof Error ? err.message : String(err),
-                });
+                try {
+                  targetWin?.webview.rpc?.send.scanError({
+                    error: err instanceof Error ? err.message : String(err),
+                  });
+                } catch (_) {}
                 activeInMemoryScanner = null;
               });
             }

--- a/electrobun/src/bun/index.ts
+++ b/electrobun/src/bun/index.ts
@@ -735,7 +735,10 @@ function createAppWindow(): BrowserWindow<any> {
   latestWindow = newWin;
 
   newWin.on("close", () => {
-    process.exit(0);
+    // Don't exit here — Electrobun's built-in exitOnLastWindowClosed
+    // (default: true) will quit when the last BrowserWindow closes.
+    // Calling process.exit(0) on every close kills the app even when
+    // other windows are still open.
   });
 
   return newWin;

--- a/electrobun/src/bun/scanner-sqlite.ts
+++ b/electrobun/src/bun/scanner-sqlite.ts
@@ -1,0 +1,738 @@
+/**
+ * SQLite-backed Filesystem Scanner
+ *
+ * Writes scan results directly into a SQLite database instead of building
+ * an in-memory tree. This keeps memory usage flat regardless of tree size
+ * and enables the backend to serve depth-limited subtrees on demand so the
+ * frontend never needs to hold the full tree.
+ *
+ * Performance notes:
+ * - WAL mode for concurrent reads during scan
+ * - Batched inserts (commit every BATCH_SIZE rows)
+ * - JS-managed IDs to avoid SELECT last_insert_rowid() round-trips
+ * - Prepared statements reused across all inserts
+ * - Directory sizes computed bottom-up after scan completes
+ */
+
+import { Database } from "bun:sqlite";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Commit inserts every N rows. */
+const BATCH_SIZE = 5_000;
+
+/** Report progress every N items. */
+const PROGRESS_INTERVAL = 10_000;
+
+/** Yield to the event loop every N items. */
+const YIELD_INTERVAL = 5_000;
+
+/** Refresh interval constants. */
+const START_REFRESH_INTERVAL = 5_000;
+const MAX_REFRESH_INTERVAL = 15 * 60 * 1_000;
+const REFRESH_MULTIPLIER = 3;
+
+/** Threshold (ms) after which we consider the scan possibly stuck. */
+const STUCK_THRESHOLD = 30_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SqliteScannerHandlers {
+  onProgress?: (
+    dir: string,
+    name: string,
+    size: number,
+    fileCount: number,
+    dirCount: number,
+    errorCount: number,
+  ) => void;
+  /** Lightweight notification — caller should query getSubtree(). */
+  onRefresh?: () => void;
+  onComplete?: (stats: SqliteScanStats) => void;
+  onError?: (error: string) => void;
+}
+
+export interface SqliteScanStats {
+  fileCount: number;
+  dirCount: number;
+  totalSize: number;
+  errorCount: number;
+  cancelled: boolean;
+}
+
+interface NodeRow {
+  id: number;
+  parent_id: number | null;
+  name: string;
+  size: number;
+  is_dir: number;
+  depth: number;
+}
+
+// ---------------------------------------------------------------------------
+// Refresh scheduler (same exponential backoff as scanner.ts)
+// ---------------------------------------------------------------------------
+
+class RefreshScheduler {
+  private running = false;
+  private interval: number;
+  private scheduledAt: number;
+  private readonly task: (reschedule: (t?: number) => void) => void;
+
+  constructor(
+    task: (reschedule: (t?: number) => void) => void,
+    interval: number,
+  ) {
+    this.task = task;
+    this.interval = interval;
+    this.scheduledAt = Date.now() + interval;
+  }
+
+  schedule(t?: number): void {
+    this.running = true;
+    if (t !== undefined) this.interval = t;
+    this.scheduledAt = Date.now() + this.interval;
+  }
+
+  cancel(): void {
+    this.running = false;
+  }
+
+  check(): void {
+    if (!this.running) return;
+    if (Date.now() >= this.scheduledAt) {
+      this.task(this.schedule.bind(this));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exclusion paths
+// ---------------------------------------------------------------------------
+
+function buildExcludePaths(homeDir: string): string[] {
+  const pjoin = path.join;
+  return [
+    pjoin(homeDir, "Library/CloudStorage"),
+    pjoin(homeDir, "Library/Containers/com.microsoft.OneDrive"),
+    pjoin(homeDir, "Library/Containers/com.microsoft.OneDrive-mac"),
+    pjoin(
+      homeDir,
+      "Library/Containers/com.microsoft.OneDriveStandaloneUpdater",
+    ),
+    pjoin(homeDir, "Library/Containers/com.microsoft.OneDrive-mac.FinderSync"),
+    "/System/Volumes/Data/.Spotlight-V100",
+    "/private/var/db",
+    "/private/var/folders",
+    "/.Spotlight-V100",
+    "/.fseventsd",
+    "/dev",
+    "/System/Volumes/VM",
+    "/System/Volumes/Preboot",
+    "/System/Volumes/Update",
+    pjoin(homeDir, "Library/Caches"),
+    pjoin(homeDir, "Library/Saved Application State"),
+    "/Volumes/.timemachine",
+    "/.MobileBackups",
+    "/.MobileBackups.trash",
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// SqliteScanner
+// ---------------------------------------------------------------------------
+
+export class SqliteScanner {
+  private db: Database;
+  private handlers: SqliteScannerHandlers;
+  private refreshScheduler: RefreshScheduler | null = null;
+
+  // Scan state
+  private scanning = false;
+  private cancelled = false;
+  private paused = false;
+  private pauseResolvers: Array<() => void> = [];
+
+  // Counters
+  private counter = 0;
+  private currentSize = 0;
+  private fileCount = 0;
+  private dirCount = 0;
+  private errorCount = 0;
+  private currentPath = "";
+  private lastProgressTime = Date.now();
+
+  // Insert batching
+  private insertStmt!: ReturnType<Database["query"]>;
+  private nextId = 1;
+  private batchCount = 0;
+  private inTransaction = false;
+  private rootId: number | null = null;
+
+  constructor(dbPath: string, handlers: SqliteScannerHandlers = {}) {
+    this.db = new Database(dbPath);
+    this.db.exec("PRAGMA journal_mode=WAL");
+    this.db.exec("PRAGMA synchronous=NORMAL");
+    this.db.exec("PRAGMA cache_size=-64000"); // 64 MB
+    this.db.exec("PRAGMA temp_store=MEMORY");
+    this.setupSchema();
+    this.handlers = handlers;
+  }
+
+  /** Update handlers (e.g. before starting a new scan on the same instance). */
+  setHandlers(handlers: SqliteScannerHandlers): void {
+    this.handlers = handlers;
+  }
+
+  // ------------------------------------------------------------------
+  // Schema
+  // ------------------------------------------------------------------
+
+  private setupSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS nodes (
+        id        INTEGER PRIMARY KEY,
+        parent_id INTEGER,
+        name      TEXT    NOT NULL,
+        size      INTEGER NOT NULL DEFAULT 0,
+        is_dir    INTEGER NOT NULL DEFAULT 0,
+        depth     INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE INDEX IF NOT EXISTS idx_parent ON nodes(parent_id);
+      CREATE INDEX IF NOT EXISTS idx_depth  ON nodes(depth);
+    `);
+  }
+
+  // ------------------------------------------------------------------
+  // Public API
+  // ------------------------------------------------------------------
+
+  async scan(targetPath: string): Promise<void> {
+    if (this.scanning) {
+      this.handlers.onError?.("A scan is already in progress");
+      return;
+    }
+
+    this.resetState();
+    this.scanning = true;
+
+    const resolvedPath = path.resolve(targetPath);
+
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.lstat(resolvedPath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.handlers.onError?.(`Cannot access path: ${msg}`);
+      this.scanning = false;
+      return;
+    }
+
+    if (!stat.isDirectory()) {
+      this.handlers.onError?.("Only directory scanning is currently supported");
+      this.scanning = false;
+      return;
+    }
+
+    // Clear previous scan data
+    this.db.exec("DELETE FROM nodes");
+    this.nextId = 1;
+
+    // Prepare insert statement
+    this.insertStmt = this.db.query(
+      "INSERT INTO nodes (id, parent_id, name, size, is_dir, depth) VALUES (?, ?, ?, ?, ?, ?)",
+    );
+
+    // Refresh scheduler
+    let refreshInterval = START_REFRESH_INTERVAL;
+    this.refreshScheduler = new RefreshScheduler((reschedule) => {
+      // Commit pending batch so the refresh query sees latest data
+      this.commitBatch();
+      this.handlers.onRefresh?.();
+      refreshInterval *= REFRESH_MULTIPLIER;
+      reschedule(Math.min(refreshInterval, MAX_REFRESH_INTERVAL));
+    }, refreshInterval);
+    this.refreshScheduler.schedule();
+
+    const homeDir = os.homedir();
+    const excludePaths = buildExcludePaths(homeDir);
+
+    const startTime = Date.now();
+    console.log(`[sqlite-scanner] Starting scan of ${resolvedPath}`);
+
+    this.beginBatch();
+
+    try {
+      await this.descendFS(
+        null, // parent_id (null for root)
+        resolvedPath,
+        resolvedPath, // root name = full path
+        0, // depth
+        excludePaths,
+        new Set<string>(),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[sqlite-scanner] Unhandled error: ${msg}`);
+      this.handlers.onError?.(msg);
+    }
+
+    // Flush remaining inserts
+    this.commitBatch();
+    this.refreshScheduler.cancel();
+    this.refreshScheduler = null;
+
+    // Compute cumulative directory sizes bottom-up
+    if (!this.cancelled) {
+      console.log("[sqlite-scanner] Computing directory sizes...");
+      this.computeDirectorySizes();
+    }
+
+    const elapsed = Date.now() - startTime;
+    const stats = this.getStats();
+    console.log(
+      `[sqlite-scanner] Scan finished in ${elapsed}ms — ` +
+        `${stats.fileCount} files, ${stats.dirCount} dirs, ` +
+        `${stats.errorCount} errors, cancelled=${stats.cancelled}`,
+    );
+
+    this.handlers.onComplete?.(stats);
+    this.scanning = false;
+  }
+
+  cancel(): void {
+    this.cancelled = true;
+    if (this.paused) this.resume();
+    console.log("[sqlite-scanner] Scan cancelled");
+  }
+
+  pause(): void {
+    if (!this.paused) {
+      this.paused = true;
+      console.log("[sqlite-scanner] Scan paused");
+    }
+  }
+
+  resume(): void {
+    if (this.paused) {
+      this.paused = false;
+      console.log("[sqlite-scanner] Scan resumed");
+      const resolvers = this.pauseResolvers;
+      this.pauseResolvers = [];
+      for (const r of resolvers) r();
+    }
+  }
+
+  /** Get the root node ID of the current/last scan. */
+  getRootId(): number | null {
+    const row = this.db
+      .query("SELECT id FROM nodes WHERE parent_id IS NULL LIMIT 1")
+      .get() as { id: number } | null;
+    return row?.id ?? null;
+  }
+
+  /**
+   * Return a depth-limited subtree as a JSON-compatible tree object.
+   * Each node has { name, size, children?, _nodeId }.
+   * Directories beyond maxDepth are returned as leaves with their
+   * cumulative size (so visualizations render correct proportions).
+   *
+   * When directory sizes haven't been computed yet (mid-scan), this
+   * method calculates them on the fly:
+   * 1. Edge directories (at maxDepth, size 0): recursive SUM of
+   *    descendant file sizes via a prepared statement per node.
+   * 2. Inner directories: bottom-up aggregation from children.
+   */
+  getSubtree(nodeId: number, maxDepth: number): any | null {
+    const rows = this.db
+      .query(
+        `WITH RECURSIVE tree AS (
+          SELECT id, parent_id, name, size, is_dir, 0 AS rel_depth
+            FROM nodes WHERE id = ?
+          UNION ALL
+          SELECT n.id, n.parent_id, n.name, n.size, n.is_dir, t.rel_depth + 1
+            FROM nodes n
+            JOIN tree t ON n.parent_id = t.id
+           WHERE t.rel_depth < ?
+        )
+        SELECT id, parent_id, name, size, is_dir, rel_depth FROM tree`,
+      )
+      .all(nodeId, maxDepth) as Array<NodeRow & { rel_depth: number }>;
+
+    if (rows.length === 0) return null;
+
+    // Build node map
+    const map = new Map<number, any>();
+    for (const r of rows) {
+      map.set(r.id, {
+        name: r.name,
+        ...(r.is_dir ? { children: [] } : { size: r.size }),
+        ...(r.is_dir && r.size > 0 ? { size: r.size } : {}),
+        _nodeId: r.id,
+      });
+    }
+
+    // Link children to parents
+    for (const r of rows) {
+      if (r.parent_id !== null && map.has(r.parent_id)) {
+        map.get(r.parent_id).children.push(map.get(r.id));
+      }
+    }
+
+    // Compute sizes for directories when computeDirectorySizes() hasn't run
+    // (i.e. during an in-progress scan). After scan completes, dirs already
+    // have correct sizes from the DB so this loop is skipped entirely.
+    const hasMissingSizes = rows.some((r) => r.is_dir && r.size === 0);
+    if (hasMissingSizes) {
+      this.fillMissingSizes(rows, map, maxDepth);
+    }
+
+    // Attach parent node ID so the frontend can navigate up past this subtree
+    const root = map.get(nodeId);
+    if (root) {
+      const rootRow = rows.find((r) => r.id === nodeId);
+      root._parentNodeId = rootRow?.parent_id ?? null;
+    }
+
+    return root ?? null;
+  }
+
+  /**
+   * Fill in missing directory sizes for a partial subtree.
+   *
+   * Phase 1 — edge directories (at maxDepth with size 0): run a recursive
+   *   CTE per node to SUM all descendant file sizes. Uses a prepared
+   *   statement so Bun's native SQLite binding avoids re-parsing.
+   *
+   * Phase 2 — inner directories: simple bottom-up aggregation from their
+   *   already-sized children (deepest first).
+   */
+  private fillMissingSizes(
+    rows: Array<NodeRow & { rel_depth: number }>,
+    map: Map<number, any>,
+    maxDepth: number,
+  ): void {
+    // Phase 1: edge directories — query descendant file sizes from the DB
+    const descSizeStmt = this.db.query(`
+      WITH RECURSIVE desc AS (
+        SELECT id, size, is_dir FROM nodes WHERE parent_id = ?
+        UNION ALL
+        SELECT n.id, n.size, n.is_dir
+          FROM nodes n
+          JOIN desc d ON n.parent_id = d.id
+      )
+      SELECT COALESCE(SUM(CASE WHEN is_dir = 0 THEN size ELSE 0 END), 0) AS total
+        FROM desc
+    `);
+
+    for (const r of rows) {
+      if (r.is_dir && r.size === 0 && r.rel_depth === maxDepth) {
+        const result = descSizeStmt.get(r.id) as { total: number } | null;
+        if (result && result.total > 0) {
+          map.get(r.id).size = result.total;
+        }
+      }
+    }
+
+    // Phase 2: inner directories — bottom-up from deepest to shallowest
+    for (let d = maxDepth - 1; d >= 0; d--) {
+      for (const r of rows) {
+        if (r.is_dir && r.size === 0 && r.rel_depth === d) {
+          const node = map.get(r.id);
+          if (node && node.children) {
+            let total = 0;
+            for (const child of node.children) total += child.size || 0;
+            if (total > 0) node.size = total;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Reconstruct the full filesystem path for a node by walking parent links.
+   */
+  getNodePath(nodeId: number): string {
+    const parts: string[] = [];
+    let current = nodeId;
+    const stmt = this.db.query(
+      "SELECT parent_id, name FROM nodes WHERE id = ?",
+    );
+    while (true) {
+      const row = stmt.get(current) as {
+        parent_id: number | null;
+        name: string;
+      } | null;
+      if (!row) break;
+      parts.unshift(row.name);
+      if (row.parent_id === null) break;
+      current = row.parent_id;
+    }
+    // The root node's name is the full resolved path, children are just names
+    // so join everything after the first element with path.sep
+    if (parts.length <= 1) return parts[0] || "";
+    return path.join(parts[0], ...parts.slice(1));
+  }
+
+  /** Close the database. */
+  close(): void {
+    try {
+      this.db.close();
+    } catch (_) {}
+  }
+
+  // ------------------------------------------------------------------
+  // Private: scan walk
+  // ------------------------------------------------------------------
+
+  private resetState(): void {
+    this.counter = 0;
+    this.currentSize = 0;
+    this.fileCount = 0;
+    this.dirCount = 0;
+    this.errorCount = 0;
+    this.currentPath = "";
+    this.lastProgressTime = Date.now();
+    this.cancelled = false;
+    this.paused = false;
+    this.pauseResolvers = [];
+    this.batchCount = 0;
+    this.inTransaction = false;
+    this.rootId = null;
+  }
+
+  private getStats(): SqliteScanStats {
+    return {
+      fileCount: this.fileCount,
+      dirCount: this.dirCount,
+      totalSize: this.currentSize,
+      errorCount: this.errorCount,
+      cancelled: this.cancelled,
+    };
+  }
+
+  private waitIfPaused(): Promise<void> {
+    if (!this.paused) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.pauseResolvers.push(resolve);
+    });
+  }
+
+  private isExcluded(dir: string, excludePaths: string[]): boolean {
+    for (const ex of excludePaths) {
+      if (
+        dir === ex ||
+        (dir.length > ex.length && dir.startsWith(ex + path.sep))
+      ) {
+        return true;
+      }
+    }
+    if (
+      dir.includes(
+        path.sep + "Library" + path.sep + "Group Containers" + path.sep,
+      ) &&
+      dir.includes("OneDrive")
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  // ------------------------------------------------------------------
+  // Private: batch insert helpers
+  // ------------------------------------------------------------------
+
+  private beginBatch(): void {
+    if (!this.inTransaction) {
+      this.db.exec("BEGIN");
+      this.inTransaction = true;
+      this.batchCount = 0;
+    }
+  }
+
+  private commitBatch(): void {
+    if (this.inTransaction) {
+      this.db.exec("COMMIT");
+      this.inTransaction = false;
+      this.batchCount = 0;
+    }
+  }
+
+  private insertNode(
+    parentId: number | null,
+    name: string,
+    size: number,
+    isDir: boolean,
+    depth: number,
+  ): number {
+    const id = this.nextId++;
+    this.insertStmt.run(id, parentId, name, size, isDir ? 1 : 0, depth);
+    this.batchCount++;
+
+    if (this.batchCount >= BATCH_SIZE) {
+      this.commitBatch();
+      this.beginBatch();
+    }
+
+    return id;
+  }
+
+  // ------------------------------------------------------------------
+  // Private: directory size aggregation
+  // ------------------------------------------------------------------
+
+  private computeDirectorySizes(): void {
+    const maxRow = this.db
+      .query("SELECT MAX(depth) AS d FROM nodes WHERE is_dir = 1")
+      .get() as { d: number | null };
+
+    const maxDepth = maxRow?.d ?? 0;
+
+    const updateStmt = this.db.query(`
+      UPDATE nodes SET size = (
+        SELECT COALESCE(SUM(c.size), 0)
+          FROM nodes c
+         WHERE c.parent_id = nodes.id
+      ) WHERE is_dir = 1 AND depth = ?
+    `);
+
+    // Bottom-up: deepest directories first
+    for (let d = maxDepth; d >= 0; d--) {
+      updateStmt.run(d);
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Private: recursive filesystem walk
+  // ------------------------------------------------------------------
+
+  private async descendFS(
+    parentId: number | null,
+    dir: string,
+    name: string,
+    depth: number,
+    excludePaths: string[],
+    seenInodes: Set<string>,
+  ): Promise<void> {
+    this.currentPath = dir;
+    this.lastProgressTime = Date.now();
+
+    // Counter, progress, refresh, yield
+    this.counter++;
+    if (this.counter % PROGRESS_INTERVAL === 0) {
+      this.handlers.onProgress?.(
+        dir,
+        name,
+        this.currentSize,
+        this.fileCount,
+        this.dirCount,
+        this.errorCount,
+      );
+    }
+    this.refreshScheduler?.check();
+    if (this.counter % YIELD_INTERVAL === 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+
+    // Exclusion / cancellation
+    if (this.isExcluded(dir, excludePaths)) return;
+    if (this.cancelled) return;
+
+    // lstat
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.lstat(dir);
+    } catch (err) {
+      const code =
+        err instanceof Error && "code" in err
+          ? (err as NodeJS.ErrnoException).code
+          : String(err);
+      console.warn(`[sqlite-scanner] lstat error: ${dir} ${code}`);
+      this.errorCount++;
+      return;
+    }
+
+    if (this.cancelled) return;
+
+    if (stat.blocks) {
+      this.currentSize += stat.blocks * 512;
+    }
+
+    // Skip special file types
+    if (
+      stat.isSymbolicLink() ||
+      stat.isSocket() ||
+      stat.isFIFO() ||
+      stat.isBlockDevice() ||
+      stat.isCharacterDevice()
+    ) {
+      return;
+    }
+
+    // Hardlink dedup
+    const inodeKey =
+      stat.ino != null && stat.dev != null ? `${stat.dev}:${stat.ino}` : null;
+
+    // ---- Regular file ----
+    if (stat.isFile()) {
+      this.fileCount++;
+      let size = stat.size;
+      if (inodeKey) {
+        if (seenInodes.has(inodeKey)) {
+          size = 0;
+        } else {
+          seenInodes.add(inodeKey);
+        }
+      }
+      this.insertNode(parentId, name, size, false, depth);
+      return;
+    }
+
+    // ---- Directory ----
+    if (stat.isDirectory()) {
+      this.dirCount++;
+      if (inodeKey) {
+        if (seenInodes.has(inodeKey)) return;
+        seenInodes.add(inodeKey);
+      }
+
+      const nodeId = this.insertNode(parentId, name, 0, true, depth);
+      if (parentId === null) this.rootId = nodeId;
+
+      let entries: string[];
+      try {
+        entries = await fs.promises.readdir(dir);
+      } catch (err) {
+        const code =
+          err instanceof Error && "code" in err
+            ? (err as NodeJS.ErrnoException).code
+            : String(err);
+        console.warn(`[sqlite-scanner] readdir error: ${dir} ${code}`);
+        this.errorCount++;
+        return;
+      }
+
+      for (const entry of entries) {
+        if (this.cancelled) return;
+        await this.waitIfPaused();
+        if (this.cancelled) return;
+
+        await this.descendFS(
+          nodeId,
+          path.join(dir, entry),
+          entry,
+          depth + 1,
+          excludePaths,
+          seenInodes,
+        );
+      }
+    }
+  }
+}

--- a/electrobun/src/bun/scanner-worker.ts
+++ b/electrobun/src/bun/scanner-worker.ts
@@ -1,0 +1,103 @@
+/**
+ * Scanner Worker
+ *
+ * Runs the filesystem scanner in a separate Bun Worker thread so the main
+ * process event loop stays free for RPC, menu events, and UI callbacks.
+ *
+ * Communication with the main thread uses postMessage:
+ *
+ * Main -> Worker:
+ *   { type: "scan",   path: string }
+ *   { type: "cancel" }
+ *   { type: "pause"  }
+ *   { type: "resume" }
+ *
+ * Worker -> Main:
+ *   { type: "started" }
+ *   { type: "progress", dir, name, size, fileCount, dirCount, errorCount }
+ *   { type: "refresh",  data: string }
+ *   { type: "complete", data: string, stats: {...} }
+ *   { type: "error",    error: string }
+ */
+
+import { Scanner } from "./scanner";
+
+let activeScanner: Scanner | null = null;
+
+self.onmessage = (event: MessageEvent) => {
+  const msg = event.data;
+
+  switch (msg.type) {
+    case "scan": {
+      // Cancel any in-progress scan before starting a new one
+      if (activeScanner) {
+        activeScanner.cancel();
+      }
+
+      activeScanner = new Scanner({
+        onProgress: (dir, name, size, fileCount, dirCount, errorCount) => {
+          self.postMessage({
+            type: "progress",
+            dir,
+            name,
+            size,
+            fileCount,
+            dirCount,
+            errorCount,
+          });
+        },
+        onRefresh: (tree) => {
+          self.postMessage({
+            type: "refresh",
+            data: JSON.stringify(tree),
+          });
+        },
+        onComplete: (tree, stats) => {
+          self.postMessage({
+            type: "complete",
+            data: JSON.stringify(tree),
+            stats: {
+              fileCount: stats.fileCount,
+              dirCount: stats.dirCount,
+              currentSize: stats.currentSize,
+              errorCount: stats.errorCount,
+              cancelled: stats.cancelled,
+            },
+          });
+        },
+        onError: (error) => {
+          self.postMessage({
+            type: "error",
+            error,
+          });
+        },
+      });
+
+      // Fire-and-forget — progress is reported via postMessage
+      activeScanner.scan(msg.path);
+      self.postMessage({ type: "started" });
+      break;
+    }
+
+    case "cancel": {
+      if (activeScanner) {
+        activeScanner.cancel();
+      }
+      break;
+    }
+
+    case "pause": {
+      if (activeScanner) {
+        activeScanner.pause();
+      }
+      break;
+    }
+
+    case "resume": {
+      if (activeScanner) {
+        activeScanner.resume();
+      }
+      break;
+    }
+  }
+};

--- a/electrobun/src/bun/scanner.ts
+++ b/electrobun/src/bun/scanner.ts
@@ -159,7 +159,7 @@ const STUCK_THRESHOLD = 30_000;
 const PROGRESS_INTERVAL = 10_000;
 
 /** Yield to the event loop every N items to prevent UI lockup. */
-const YIELD_INTERVAL = 1_000;
+const YIELD_INTERVAL = 5_000;
 
 /** Refresh interval constants. */
 const START_REFRESH_INTERVAL = 5_000;

--- a/electrobun/src/bun/scanner.ts
+++ b/electrobun/src/bun/scanner.ts
@@ -1,0 +1,524 @@
+/**
+ * Space Radar Filesystem Scanner
+ *
+ * TypeScript port of app/js/du.js (async filesystem walker) and
+ * app/js/scanner.js (scan orchestrator) for the Electrobun migration.
+ *
+ * Runs in the Bun main process. Walks the filesystem asynchronously,
+ * building a tree of { name, size?, children? } nodes, with support for
+ * cancel/pause/resume, hardlink deduplication, exclusion paths, and
+ * exponentially backing-off refresh callbacks.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+// ---------------------------------------------------------------------------
+// Tree node types
+// ---------------------------------------------------------------------------
+
+export interface TreeNode {
+  name: string;
+  size?: number;
+  children?: TreeNode[];
+  _isFreeSpace?: boolean;
+  _isOtherFiles?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Scan statistics
+// ---------------------------------------------------------------------------
+
+export interface ScanStats {
+  counter: number;
+  currentSize: number;
+  fileCount: number;
+  dirCount: number;
+  errorCount: number;
+  currentPath: string;
+  lastProgressTime: number;
+  possiblyStuck: boolean;
+  cancelled: boolean;
+  paused: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Scanner event handlers
+// ---------------------------------------------------------------------------
+
+export interface ScannerHandlers {
+  onProgress?: (
+    dir: string,
+    name: string,
+    size: number,
+    fileCount: number,
+    dirCount: number,
+    errorCount: number,
+  ) => void;
+  onRefresh?: (tree: TreeNode) => void;
+  onComplete?: (tree: TreeNode, stats: ScanStats) => void;
+  onError?: (error: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: options bag threaded through the recursive walk
+// ---------------------------------------------------------------------------
+
+interface DescendOptions {
+  parent: string;
+  name: string | null;
+  node: TreeNode;
+  excludePaths: string[];
+  seenInodes: Set<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Refresh scheduler (port of utils.js TaskChecker)
+// ---------------------------------------------------------------------------
+
+class RefreshScheduler {
+  private running = false;
+  private interval: number;
+  private scheduledAt: number;
+  private readonly task: (reschedule: (t?: number) => void) => void;
+
+  constructor(
+    task: (reschedule: (t?: number) => void) => void,
+    interval: number,
+  ) {
+    this.task = task;
+    this.interval = interval;
+    this.scheduledAt = Date.now() + interval;
+  }
+
+  schedule(t?: number): void {
+    this.running = true;
+    if (t !== undefined) {
+      this.interval = t;
+    }
+    this.scheduledAt = Date.now() + this.interval;
+  }
+
+  cancel(): void {
+    this.running = false;
+  }
+
+  /** Called on every progress tick — runs the task if enough time has passed. */
+  check(): void {
+    if (!this.running) return;
+    if (Date.now() >= this.scheduledAt) {
+      this.task(this.schedule.bind(this));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default exclusion paths (from scanner.js)
+// ---------------------------------------------------------------------------
+
+function buildExcludePaths(homeDir: string): string[] {
+  const pjoin = path.join;
+  return [
+    // Cloud storage paths that can cause hangs or incomplete data
+    pjoin(homeDir, "Library/CloudStorage"),
+    pjoin(homeDir, "Library/Containers/com.microsoft.OneDrive"),
+    pjoin(homeDir, "Library/Containers/com.microsoft.OneDrive-mac"),
+    pjoin(
+      homeDir,
+      "Library/Containers/com.microsoft.OneDriveStandaloneUpdater",
+    ),
+    pjoin(homeDir, "Library/Containers/com.microsoft.OneDrive-mac.FinderSync"),
+    // macOS system paths that often cause permission issues or hangs
+    "/System/Volumes/Data/.Spotlight-V100",
+    "/private/var/db",
+    "/private/var/folders",
+    "/.Spotlight-V100",
+    "/.fseventsd",
+    "/dev",
+    "/System/Volumes/VM",
+    "/System/Volumes/Preboot",
+    "/System/Volumes/Update",
+    pjoin(homeDir, "Library/Caches"),
+    pjoin(homeDir, "Library/Saved Application State"),
+    // Time Machine
+    "/Volumes/.timemachine",
+    "/.MobileBackups",
+    "/.MobileBackups.trash",
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Scanner class
+// ---------------------------------------------------------------------------
+
+/** Threshold (ms) after which we consider the scan possibly stuck. */
+const STUCK_THRESHOLD = 30_000;
+
+/** Report progress every N items. */
+const PROGRESS_INTERVAL = 10_000;
+
+/** Refresh interval constants. */
+const START_REFRESH_INTERVAL = 5_000;
+const MAX_REFRESH_INTERVAL = 15 * 60 * 1_000;
+const REFRESH_MULTIPLIER = 3;
+
+export class Scanner {
+  // ---- state ----
+  private counter = 0;
+  private currentSize = 0;
+  private fileCount = 0;
+  private dirCount = 0;
+  private errorCount = 0;
+  private currentPath = "";
+  private lastProgressTime = Date.now();
+  private cancelled = false;
+  private paused = false;
+  private pauseResolvers: Array<() => void> = [];
+  private scanning = false;
+
+  // ---- handlers ----
+  private handlers: ScannerHandlers;
+
+  constructor(handlers: ScannerHandlers = {}) {
+    this.handlers = handlers;
+  }
+
+  // ------------------------------------------------------------------
+  // Public API
+  // ------------------------------------------------------------------
+
+  /** Start scanning `targetPath`. Resolves when the scan finishes. */
+  async scan(targetPath: string): Promise<void> {
+    if (this.scanning) {
+      this.handlers.onError?.("A scan is already in progress");
+      return;
+    }
+
+    this.resetCounters();
+    this.scanning = true;
+
+    const resolvedPath = path.resolve(targetPath);
+
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.lstat(resolvedPath);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.handlers.onError?.(`Cannot access path: ${msg}`);
+      this.scanning = false;
+      return;
+    }
+
+    if (!stat.isDirectory()) {
+      // TODO: support du-file reading in a future pass
+      this.handlers.onError?.("Only directory scanning is currently supported");
+      this.scanning = false;
+      return;
+    }
+
+    const homeDir = os.homedir();
+    const excludePaths = buildExcludePaths(homeDir);
+    const tree: TreeNode = { name: "" };
+
+    // ---- Refresh scheduler ----
+    let refreshInterval = START_REFRESH_INTERVAL;
+
+    const refreshScheduler = new RefreshScheduler((reschedule) => {
+      this.handlers.onRefresh?.(tree);
+      refreshInterval *= REFRESH_MULTIPLIER;
+      reschedule(Math.min(refreshInterval, MAX_REFRESH_INTERVAL));
+    }, refreshInterval);
+
+    refreshScheduler.schedule();
+
+    // ---- Walk ----
+    const startTime = Date.now();
+    console.log(`[scanner] Starting scan of ${resolvedPath}`);
+
+    try {
+      await this.descendFS({
+        parent: resolvedPath,
+        name: null,
+        node: tree,
+        excludePaths,
+        seenInodes: new Set<string>(),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[scanner] Unhandled error during scan: ${msg}`);
+      this.handlers.onError?.(msg);
+    }
+
+    refreshScheduler.cancel();
+
+    const elapsed = Date.now() - startTime;
+    console.log(
+      `[scanner] Scan finished in ${elapsed}ms — ` +
+        `${this.fileCount} files, ${this.dirCount} dirs, ` +
+        `${this.errorCount} errors, cancelled=${this.cancelled}`,
+    );
+
+    const finalStats = this.getStats();
+    this.handlers.onComplete?.(tree, finalStats);
+    this.scanning = false;
+  }
+
+  /** Cancel the current scan. */
+  cancel(): void {
+    this.cancelled = true;
+    // Resume if paused so pending awaits can settle
+    if (this.paused) {
+      this.resume();
+    }
+    console.log("[scanner] Scan cancelled by user");
+  }
+
+  /** Pause the current scan. */
+  pause(): void {
+    if (!this.paused) {
+      this.paused = true;
+      console.log("[scanner] Scan paused");
+    }
+  }
+
+  /** Resume a paused scan. */
+  resume(): void {
+    if (this.paused) {
+      this.paused = false;
+      console.log("[scanner] Scan resumed");
+      const resolvers = this.pauseResolvers;
+      this.pauseResolvers = [];
+      for (const resolve of resolvers) {
+        resolve();
+      }
+    }
+  }
+
+  /** Return a snapshot of the current scan statistics. */
+  getStats(): ScanStats {
+    return {
+      counter: this.counter,
+      currentSize: this.currentSize,
+      fileCount: this.fileCount,
+      dirCount: this.dirCount,
+      errorCount: this.errorCount,
+      currentPath: this.currentPath,
+      lastProgressTime: this.lastProgressTime,
+      possiblyStuck: Date.now() - this.lastProgressTime > STUCK_THRESHOLD,
+      cancelled: this.cancelled,
+      paused: this.paused,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Private helpers
+  // ------------------------------------------------------------------
+
+  private resetCounters(): void {
+    this.counter = 0;
+    this.currentSize = 0;
+    this.fileCount = 0;
+    this.dirCount = 0;
+    this.errorCount = 0;
+    this.currentPath = "";
+    this.lastProgressTime = Date.now();
+    this.cancelled = false;
+    this.paused = false;
+    this.pauseResolvers = [];
+  }
+
+  /**
+   * Returns a promise that resolves immediately if not paused,
+   * or waits until `resume()` is called.
+   */
+  private waitIfPaused(): Promise<void> {
+    if (!this.paused) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.pauseResolvers.push(resolve);
+    });
+  }
+
+  /**
+   * Check whether `dir` matches any exclusion path.
+   * A path is excluded if it equals an exclusion entry or is a descendant of
+   * one (i.e. starts with `exclusion + path.sep`).
+   */
+  private isExcluded(dir: string, excludePaths: string[]): boolean {
+    for (const ex of excludePaths) {
+      if (
+        dir === ex ||
+        (dir.length > ex.length && dir.startsWith(ex + path.sep))
+      ) {
+        return true;
+      }
+    }
+    // Special-case: Exclude OneDrive data inside Group Containers
+    if (
+      dir.includes(
+        path.sep + "Library" + path.sep + "Group Containers" + path.sep,
+      ) &&
+      dir.includes("OneDrive")
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Async recursive filesystem descender.
+   * Port of du.js `descendFS`, rewritten with async/await for cleaner
+   * pause/resume semantics.
+   */
+  private async descendFS(opts: DescendOptions): Promise<void> {
+    const { node, excludePaths, seenInodes } = opts;
+
+    // Resolve the full directory path
+    let dir: string;
+    let name: string;
+    if (opts.name === null) {
+      dir = opts.parent;
+      name = opts.parent;
+    } else {
+      dir = path.join(opts.parent, opts.name);
+      name = opts.name;
+    }
+
+    // Track current path for external visibility
+    this.currentPath = dir;
+    this.lastProgressTime = Date.now();
+
+    // Bump counter and emit progress periodically
+    this.counter++;
+    if (this.counter % PROGRESS_INTERVAL === 0) {
+      this.handlers.onProgress?.(
+        dir,
+        name,
+        this.currentSize,
+        this.fileCount,
+        this.dirCount,
+        this.errorCount,
+      );
+    }
+
+    // Exclusion check
+    if (this.isExcluded(dir, excludePaths)) {
+      return;
+    }
+
+    // Bail on cancellation
+    if (this.cancelled) return;
+
+    // lstat
+    let stat: fs.Stats;
+    try {
+      stat = await fs.promises.lstat(dir);
+    } catch (err) {
+      const code =
+        err instanceof Error && "code" in err
+          ? (err as NodeJS.ErrnoException).code
+          : String(err);
+      console.warn(`[scanner] lstat error: ${dir} ${code}`);
+      this.errorCount++;
+      return;
+    }
+
+    // Post-lstat cancellation check
+    if (this.cancelled) return;
+
+    // Accumulate block-based size
+    if (stat.blocks) {
+      this.currentSize += stat.blocks * 512;
+    }
+
+    // ---- Skip special file types ----
+    if (stat.isSymbolicLink()) return;
+    if (stat.isSocket()) {
+      console.log(`[scanner] Skipping socket: ${dir}`);
+      return;
+    }
+    if (stat.isFIFO()) {
+      console.log(`[scanner] Skipping FIFO: ${dir}`);
+      return;
+    }
+    if (stat.isBlockDevice()) {
+      console.log(`[scanner] Skipping block device: ${dir}`);
+      return;
+    }
+    if (stat.isCharacterDevice()) {
+      console.log(`[scanner] Skipping character device: ${dir}`);
+      return;
+    }
+
+    // ---- Inode key for hardlink deduplication ----
+    const inodeKey =
+      stat.ino != null && stat.dev != null ? `${stat.dev}:${stat.ino}` : null;
+
+    // ---- Regular file ----
+    if (stat.isFile()) {
+      this.fileCount++;
+      let size = stat.size;
+      if (inodeKey) {
+        if (seenInodes.has(inodeKey)) {
+          size = 0; // hardlink duplicate – don't double-count
+        } else {
+          seenInodes.add(inodeKey);
+        }
+      }
+      node.name = name;
+      node.size = size;
+      return;
+    }
+
+    // ---- Directory ----
+    if (stat.isDirectory()) {
+      this.dirCount++;
+      if (inodeKey) {
+        if (seenInodes.has(inodeKey)) {
+          return; // directory hardlink / bind-mount duplicate
+        }
+        seenInodes.add(inodeKey);
+      }
+
+      node.name = name;
+      node.children = [];
+
+      let entries: string[];
+      try {
+        entries = await fs.promises.readdir(dir);
+      } catch (err) {
+        const code =
+          err instanceof Error && "code" in err
+            ? (err as NodeJS.ErrnoException).code
+            : String(err);
+        console.warn(`[scanner] readdir error: ${dir} ${code}`);
+        this.errorCount++;
+        return;
+      }
+
+      for (const entry of entries) {
+        if (this.cancelled) return;
+
+        // Honour pause
+        await this.waitIfPaused();
+        if (this.cancelled) return;
+
+        const childNode: TreeNode = { name: "" };
+        node.children.push(childNode);
+
+        await this.descendFS({
+          parent: dir,
+          name: entry,
+          node: childNode,
+          excludePaths,
+          seenInodes,
+        });
+      }
+
+      return;
+    }
+
+    // Unknown file type
+    console.log(`[scanner] Skipping unknown file type: ${dir}`);
+  }
+}

--- a/electrobun/src/mainview/index.html
+++ b/electrobun/src/mainview/index.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <div class="window" id="photon-window">
-      <header class="toolbar toolbar-header">
+      <header class="toolbar toolbar-header electrobun-webkit-app-region-drag">
         <h1 class="title">Space Radar</h1>
 
         <div class="toolbar-actions">

--- a/electrobun/src/mainview/index.html
+++ b/electrobun/src/mainview/index.html
@@ -191,33 +191,39 @@
             id="bottom_status"
             style="
               flex: 1;
+              min-width: 0;
               align-self: center;
               font-size: 11px;
               padding-left: 8px;
               white-space: nowrap;
-              overflow: auto;
+              overflow: hidden;
+              text-overflow: ellipsis;
             "
             ><!-- Welcome to Space Radar --></span
           >
-          <button class="btn btn-default pull-right" id="dir_opener">
-            Locate Directory
-          </button>
-
-          <button
-            class="btn btn-negative pull-right"
-            id="cancel_scan_btn"
-            style="display: none; margin-right: 5px"
+          <div
+            style="flex-shrink: 0; display: flex; gap: 5px; margin-left: auto"
           >
-            Cancel Scan
-          </button>
+            <button class="btn btn-default" id="dir_opener">
+              Locate Directory
+            </button>
 
-          <button
-            class="btn btn-default pull-right"
-            id="pause_scan_btn"
-            style="display: none; margin-right: 5px"
-          >
-            Pause Scan
-          </button>
+            <button
+              class="btn btn-negative"
+              id="cancel_scan_btn"
+              style="display: none"
+            >
+              Cancel Scan
+            </button>
+
+            <button
+              class="btn btn-default"
+              id="pause_scan_btn"
+              style="display: none"
+            >
+              Pause Scan
+            </button>
+          </div>
         </div>
       </footer>
     </div>

--- a/electrobun/src/mainview/index.html
+++ b/electrobun/src/mainview/index.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Space Radar</title>
+    <link rel="stylesheet" href="style.css" type="text/css" />
+  </head>
+  <body>
+    <div class="window" id="photon-window">
+      <header class="toolbar toolbar-header">
+        <h1 class="title">Space Radar</h1>
+
+        <div class="toolbar-actions">
+          <button class="btn btn-default btn-large" id="btn-new-window">
+            <span class="icon icon-popup icon-text"></span>
+            Open
+          </button>
+
+          <div class="btn-group">
+            <button class="btn btn-default btn-large" id="btn-scan-root">
+              <span class="icon icon-drive icon-text"></span>
+              Scan Drive
+            </button>
+
+            <button class="btn btn-default btn-large" id="btn-scan-folder">
+              <span class="icon icon-folder icon-text"></span>
+              Scan Folder
+            </button>
+
+            <button class="btn btn-default btn-large" id="btn-read-file">
+              <span class="icon icon-folder icon-text"></span>
+              Load DU file
+            </button>
+
+            <button class="btn btn-default btn-large" id="btn-scan-memory">
+              <span class="icon icon-target icon-text"></span>
+              Scan Memory
+            </button>
+          </div>
+
+          <div class="btn-group">
+            <button class="btn btn-default btn-large" id="btn-show-less">
+              <span class="icon icon-minus"></span>
+            </button>
+            <button class="btn btn-default btn-large" id="btn-show-more">
+              <span class="icon icon-plus"></span>
+            </button>
+          </div>
+
+          <button class="btn btn-default btn-large" id="btn-navigate-up">
+            <span class="icon icon-up-circled"></span>
+          </button>
+
+          <!-- Large button group -->
+          <div class="btn-group pull-right">
+            <button
+              class="btn btn-large btn-default active mode_buttons"
+              id="sunburst_button"
+            >
+              <span class="icon icon-cd"></span>
+            </button>
+
+            <button
+              class="btn btn-large btn-default mode_buttons"
+              id="flamegraph_button"
+            >
+              <span class="icon icon-water"></span>
+            </button>
+
+            <button
+              class="btn btn-default btn-large mode_buttons"
+              id="treemap_button"
+            >
+              <span class="icon icon-layout"></span>
+            </button>
+          </div>
+          <div></div>
+          <!-- thin padding -->
+        </div>
+      </header>
+
+      <!-- Your app's content goes inside .window-content -->
+      <div class="window-content" style="overflow-y: hidden">
+        <div id="shades" class="Aligner">
+          <div class="Aligner-item">
+            <div id="promptbox">
+              <h4>Scan Space</h4>
+              <p>
+                Pick one of the following to scan, or drag a target folder here.
+              </p>
+
+              <div class="">
+                <button class="btn btn-default btn-large" id="prompt-scan-root">
+                  <span class="icon icon-drive icon-text"></span>
+                  Scan Drive
+                </button>
+
+                <button
+                  class="btn btn-default btn-large"
+                  id="prompt-scan-folder"
+                >
+                  <span class="icon icon-folder icon-text"></span>
+                  Scan Folder
+                </button>
+
+                <br />
+
+                <button class="btn btn-default btn-large" id="prompt-read-file">
+                  <span class="icon icon-folder icon-text"></span>
+                  Load DU file
+                </button>
+
+                <button
+                  class="btn btn-default btn-large"
+                  id="prompt-scan-memory"
+                >
+                  <span class="icon icon-target icon-text"></span>
+                  Scan Memory
+                </button>
+
+                <button class="btn btn-default btn-large" id="prompt-load-last">
+                  <span class="icon icon-back icon-text"></span>
+                  Last loaded
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!--
+  Graph Charting Plugins HERE
+-->
+
+        <canvas id="canvas" class="graph-container"></canvas>
+
+        <canvas
+          id="three-canvas"
+          class="graph-container"
+          style="display: none; z-index: 1000; position: absolute; opacity: 0.5"
+        ></canvas>
+
+        <canvas id="sunburst-canvas" class="graph-container"></canvas>
+
+        <div id="sunburst-chart" class="graph-container">
+          <div id="explanation">
+            <span id="core_top"><!-- Loading... --></span><br />
+            <span id="core_center"></span><br />
+            <span id="core_tag"></span>
+          </div>
+        </div>
+
+        <div id="flame-chart" class="svg-container graph-container"></div>
+
+        <div id="sidebar">
+          <nav class="nav-group"></nav>
+        </div>
+
+        <div id="loading">
+          Refreshing...
+          <div class="throbber-loader">Loading...</div>
+        </div>
+
+        <div id="legend"></div>
+
+        <div id="sequence">
+          <div class="breadcrumb flat"></div>
+        </div>
+      </div>
+      <!-- end window-content -->
+      <footer class="toolbar toolbar-footer">
+        <div class="toolbar-actions" style="display: flex">
+          <div class="btn-group">
+            <button class="btn btn-default" id="btn-nav-back">
+              <span class="icon icon-left-bold"></span>
+            </button>
+            <button class="btn btn-default" id="btn-nav-forward">
+              <span class="icon icon-right-bold"></span>
+            </button>
+          </div>
+
+          <span
+            id="disk_space_info"
+            style="
+              align-self: center;
+              font-size: 11px;
+              padding-left: 8px;
+              white-space: nowrap;
+            "
+          ></span>
+          <span
+            id="bottom_status"
+            style="
+              flex: 1;
+              align-self: center;
+              font-size: 11px;
+              padding-left: 8px;
+              white-space: nowrap;
+              overflow: auto;
+            "
+            ><!-- Welcome to Space Radar --></span
+          >
+          <button class="btn btn-default pull-right" id="dir_opener">
+            Locate Directory
+          </button>
+
+          <button
+            class="btn btn-negative pull-right"
+            id="cancel_scan_btn"
+            style="display: none; margin-right: 5px"
+          >
+            Cancel Scan
+          </button>
+
+          <button
+            class="btn btn-default pull-right"
+            id="pause_scan_btn"
+            style="display: none; margin-right: 5px"
+          >
+            Pause Scan
+          </button>
+        </div>
+      </footer>
+    </div>
+    <!-- end window -->
+
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -2086,8 +2086,15 @@ class FlameGraph extends Chart {
   }
 
   generate(data: any) {
-    // Clone to avoid mutating the shared tree
-    const cloned = JSON.parse(JSON.stringify(data));
+    // Clone to avoid mutating the shared tree. Use a replacer to skip
+    // circular .parent references added by d3 partition layouts (sunburst/
+    // treemap process the data before flamegraph sees it).
+    const cloned = JSON.parse(
+      JSON.stringify(data, (key, value) => {
+        if (key === "parent" || key === "_parent") return undefined;
+        return value;
+      }),
+    );
 
     // Compute value bottom-up
     function computeValue(node: any): number {

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -54,27 +54,53 @@ const rpc = Electroview.defineRPC<SpaceRadarRPC>({
           params.errorCount,
         );
       },
-      scanRefresh(params) {
-        try {
-          const json = JSON.parse(params.data);
-          refresh(json);
-        } catch (e) {
-          console.error("[renderer] Failed to parse scanRefresh data:", e);
-        }
+      scanRefresh(_params) {
+        // Tree data was flushed to file — pull it on demand
+        electroview.rpc.request
+          .loadScanPreview({})
+          .then((data) => {
+            if (data) {
+              try {
+                const json = JSON.parse(data);
+                refresh(json);
+              } catch (e) {
+                console.error(
+                  "[renderer] Failed to parse scanRefresh data:",
+                  e,
+                );
+              }
+            }
+          })
+          .catch((e) =>
+            console.error("[renderer] Failed to load scan preview:", e),
+          );
       },
       scanComplete(params) {
-        try {
-          const json = JSON.parse(params.data);
-          complete(json, {
-            fileCount: params.stats.fileCount,
-            dirCount: params.stats.dirCount,
-            current_size: params.stats.currentSize,
-            errorCount: params.stats.errorCount,
-            cancelled: params.stats.cancelled,
-          });
-        } catch (e) {
-          console.error("[renderer] Failed to parse scanComplete data:", e);
-        }
+        // Tree data was flushed to file — pull it on demand
+        electroview.rpc.request
+          .loadScanPreview({})
+          .then((data) => {
+            if (data) {
+              try {
+                const json = JSON.parse(data);
+                complete(json, {
+                  fileCount: params.stats.fileCount,
+                  dirCount: params.stats.dirCount,
+                  current_size: params.stats.currentSize,
+                  errorCount: params.stats.errorCount,
+                  cancelled: params.stats.cancelled,
+                });
+              } catch (e) {
+                console.error(
+                  "[renderer] Failed to parse scanComplete data:",
+                  e,
+                );
+              }
+            }
+          })
+          .catch((e) =>
+            console.error("[renderer] Failed to load scan preview:", e),
+          );
       },
       scanError(params) {
         console.error("[renderer] Scan error:", params.error);

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -87,6 +87,11 @@ const rpc = Electroview.defineRPC<SpaceRadarRPC>({
           );
       },
       scanComplete(params) {
+        // Show immediate feedback — the getSubtree(depth:5) RPC can be slow
+        legend.html("<h2>Loading scan results...</h2>");
+        legend.style("display", "block");
+        lightbox(true);
+
         // Try SQLite first; fall back to file-based preview
         electroview.rpc.request
           .getScanRootId({})
@@ -2764,6 +2769,11 @@ function refresh(json: any) {
       console.error("[renderer] refresh onJson error:", err);
     }
     lightbox(false);
+    // Hide the legend after preview renders — the progress handler will
+    // re-show it on the next scanProgress tick if the scan is still running.
+    // This prevents "Generating preview..." from lingering after the
+    // charts are already visible.
+    legend.style("display", "none");
   }, 1000);
 }
 

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -3027,6 +3027,13 @@ function wireButton(id: string, handler: () => void) {
   if (el) el.addEventListener("click", handler);
 }
 
+// Prevent toolbar button clicks from triggering window drag
+// (Electrobun's drag region handler is on document.mousedown and uses
+//  target.closest() which would match .toolbar-header on any child click)
+document.querySelectorAll(".toolbar-actions").forEach((el) => {
+  el.addEventListener("mousedown", (e) => e.stopPropagation());
+});
+
 // Toolbar buttons
 wireButton("btn-new-window", newWindow);
 wireButton("btn-scan-root", scanRoot);

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -2152,7 +2152,7 @@ class FlameGraph extends Chart {
 
     const totalValue = this.data.value || 1;
 
-    // Lay out flame rectangles top-down (root at top)
+    // Lay out flame rectangles bottom-up (root at bottom, children stack upward)
     const queue: Array<{
       node: any;
       depth: number;
@@ -2164,8 +2164,8 @@ class FlameGraph extends Chart {
       const { node, depth, x, w } = queue.shift()!;
       if (depth > this.LEVELS) continue;
 
-      const y = depth * cellH;
-      if (y + cellH > canvasH) continue;
+      const y = canvasH - (depth + 1) * cellH;
+      if (y < 0) continue;
       if (w < 1) continue;
 
       // Determine color

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -922,12 +922,11 @@ function computeNodeSize(data: any): void {
   console.timeEnd("computeNodeSize");
 }
 
-function setNodeFilter(data: any): any {
-  const LEVELS = 11;
+function setNodeFilter(data: any, levels: number = 11): any {
   const HIDE_THRESHOLD = 0.1;
 
   return partition.children(function hideChildren(d: any, depth: number) {
-    if (depth >= LEVELS) return null;
+    if (depth >= levels) return null;
     if (!d._children) return null;
 
     const visibleChildren: any[] = [];
@@ -1305,7 +1304,7 @@ function SunBurst() {
   function computeVisibleNodes(node: any) {
     if (!node) return;
 
-    setNodeFilter(node);
+    setNodeFilter(node, LEVELS);
     const nodes = partition.nodes(node).slice(1);
 
     let maxDepth = 0;
@@ -1373,7 +1372,9 @@ function SunBurst() {
 
     log("Root count", root.count, "ROOT size", format(root.value));
 
-    setNodeFilter(root).value((d: any) => (USE_COUNT ? d.count : d.sum));
+    setNodeFilter(root, LEVELS).value((d: any) =>
+      USE_COUNT ? d.count : d.sum,
+    );
 
     computeVisibleNodes(root);
     updateCore(root);

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -380,9 +380,12 @@ function getNodeFromPath(pathKeys: string[], root: any): any {
   }
 
   while (i < pathKeys.length && (name = pathKeys[i++])) {
-    const children = n.children
-      ? n.children.filter((c: any) => c.name === name)
-      : [];
+    // Use _children (original unfiltered) when available, falling back to
+    // .children. After the sunburst's partition layout, .children contains
+    // only filtered visible nodes (>0.1% threshold), while _children holds
+    // the complete original set.
+    const pool = n._children || n.children;
+    const children = pool ? pool.filter((c: any) => c.name === name) : [];
     if (!children[0]) return n;
     n = children[0];
   }

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -3030,9 +3030,14 @@ function wireButton(id: string, handler: () => void) {
 // Prevent toolbar button clicks from triggering window drag
 // (Electrobun's drag region handler is on document.mousedown and uses
 //  target.closest() which would match .toolbar-header on any child click)
-document.querySelectorAll(".toolbar-actions").forEach((el) => {
-  el.addEventListener("mousedown", (e) => e.stopPropagation());
-});
+// Only block on actual interactive elements so empty toolbar space stays draggable.
+document
+  .querySelectorAll(
+    ".toolbar-header button, .toolbar-header input, .toolbar-header select, .toolbar-header a, .toolbar-header .btn-group",
+  )
+  .forEach((el) => {
+    el.addEventListener("mousedown", (e) => e.stopPropagation());
+  });
 
 // Toolbar buttons
 wireButton("btn-new-window", newWindow);

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -2769,11 +2769,10 @@ function refresh(json: any) {
       console.error("[renderer] refresh onJson error:", err);
     }
     lightbox(false);
-    // Hide the legend after preview renders — the progress handler will
-    // re-show it on the next scanProgress tick if the scan is still running.
-    // This prevents "Generating preview..." from lingering after the
-    // charts are already visible.
-    legend.style("display", "none");
+    // Replace "Generating preview..." with a brief status so the legend
+    // doesn't linger with stale text. The next scanProgress tick will
+    // overwrite this with real stats if the scan is still running.
+    legend.html("<h2>Scanning...</h2>");
   }, 1000);
 }
 

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -116,12 +116,35 @@ const rpc = Electroview.defineRPC<SpaceRadarRPC>({
                   "[renderer] Failed to parse scanComplete data:",
                   e,
                 );
+                // Reset scanning state so the UI doesn't stay stuck
+                isScanning = false;
+                isPaused = false;
+                updateScanButtons();
+                legend.style("display", "none");
+                lightbox(false);
+                bottomStatus.textContent =
+                  "Error: failed to parse scan results";
               }
+            } else {
+              // No data returned — still reset scanning state
+              isScanning = false;
+              isPaused = false;
+              updateScanButtons();
+              legend.style("display", "none");
+              lightbox(false);
+              bottomStatus.textContent = "Scan complete but no data returned";
             }
           })
-          .catch((e) =>
-            console.error("[renderer] Failed to load scan preview:", e),
-          );
+          .catch((e) => {
+            console.error("[renderer] Failed to load scan preview:", e);
+            // Reset scanning state so the UI doesn't stay stuck
+            isScanning = false;
+            isPaused = false;
+            updateScanButtons();
+            legend.style("display", "none");
+            lightbox(false);
+            bottomStatus.textContent = "Error: failed to load scan results";
+          });
       },
       scanError(params) {
         console.error("[renderer] Scan error:", params.error);

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -1,0 +1,3081 @@
+/**
+ * Space Radar - Electrobun WebView Renderer Entry Point
+ *
+ * This single bundled file replaces the 20+ script tags from the Electron version.
+ * All modules are unified here with explicit scoping instead of globals.
+ *
+ * RPC replaces: ipcRenderer, localStorage IPC, temp file compressed IPC, webContents.send
+ */
+
+import { Electroview } from "electrobun/view";
+import type { SpaceRadarRPC } from "../shared/types";
+
+// =============================================================================
+// D3 Setup - d3 v3 with augmentations
+// =============================================================================
+
+import * as d3 from "d3";
+import * as d3Hierarchy from "d3-hierarchy";
+import * as d3Scale from "d3-scale";
+import * as d3Selection from "d3-selection";
+import * as d3Ease from "d3-ease";
+import { flamegraph } from "d3-flame-graph";
+import { defaultFlamegraphTooltip } from "d3-flame-graph/dist/d3-flamegraph-tooltip.js";
+
+// Merge d3 modules (d3 v3 base + newer modules)
+// Note: Cannot Object.assign onto d3 directly because Bun's bundler wraps
+// ESM namespace objects with getter-only property descriptors (readonly).
+// Merge into a new plain object instead.
+const d3Merged: any = Object.assign(
+  {},
+  d3,
+  d3Hierarchy,
+  d3Scale,
+  d3Selection,
+  d3Ease,
+);
+
+// =============================================================================
+// Electroview RPC Setup
+// =============================================================================
+
+const rpc = Electroview.defineRPC<SpaceRadarRPC>({
+  handlers: {
+    requests: {},
+    messages: {
+      scanProgress(params) {
+        progress(
+          params.dir,
+          params.name,
+          params.size,
+          params.fileCount,
+          params.dirCount,
+          params.errorCount,
+        );
+      },
+      scanRefresh(params) {
+        try {
+          const json = JSON.parse(params.data);
+          refresh(json);
+        } catch (e) {
+          console.error("[renderer] Failed to parse scanRefresh data:", e);
+        }
+      },
+      scanComplete(params) {
+        try {
+          const json = JSON.parse(params.data);
+          complete(json, {
+            fileCount: params.stats.fileCount,
+            dirCount: params.stats.dirCount,
+            current_size: params.stats.currentSize,
+            errorCount: params.stats.errorCount,
+            cancelled: params.stats.cancelled,
+          });
+        } catch (e) {
+          console.error("[renderer] Failed to parse scanComplete data:", e);
+        }
+      },
+      scanError(params) {
+        console.error("[renderer] Scan error:", params.error);
+        isScanning = false;
+        isPaused = false;
+        updateScanButtons();
+        legend.style("display", "none");
+        lightbox(false);
+        bottomStatus.textContent = "Error: " + params.error;
+      },
+      colorChange(params) {
+        if (params.type === "scheme") {
+          switchColorScheme(params.value);
+        } else if (params.type === "mode") {
+          switchColorMode(params.value);
+        } else if (params.type === "darkMode") {
+          toggleDarkMode(params.value === "true" || params.value === true);
+        }
+      },
+      contextMenuClicked(params) {
+        if (params.action === "show-selection") {
+          showSelection();
+        } else if (params.action === "open-selection") {
+          openSelection();
+        } else if (params.action === "trash-selection") {
+          trashSelection();
+        }
+      },
+    },
+  },
+});
+const electroview = new Electroview({ rpc });
+
+// =============================================================================
+// UTILS (from app/js/utils.js)
+// =============================================================================
+
+function format(bytes: number | null | undefined): string {
+  if (bytes == null || isNaN(bytes as number)) {
+    return "0 B";
+  }
+
+  const kb = bytes / 1024;
+  const mb = bytes / 1024 / 1024;
+  const gb = bytes / 1024 / 1024 / 1024;
+  const tb = bytes / 1024 / 1024 / 1024 / 1024;
+
+  const units: Record<string, number> = { KB: kb, MB: mb, GB: gb, TB: tb };
+
+  let last_unit = "B";
+  let last_value: string = String(bytes);
+  for (const u in units) {
+    if (units[u] < 1) {
+      return last_value + " " + last_unit;
+    }
+    last_unit = u;
+    last_value = units[u].toFixed(2);
+  }
+  return last_value + " " + last_unit;
+}
+
+let last_time = Date.now();
+
+function fmt_time(ms: number): string {
+  const s = ms / 1000;
+  const m = s / 60;
+
+  if (s < 10) return ms + "ms";
+  if (m < 1) return s.toFixed(2) + "s";
+
+  const sRem = (s % 60) | 0;
+  const sStr = sRem === 0 ? "00" : sRem > 10 ? String(sRem) : "0" + sRem;
+  return (m | 0) + ":" + sStr + "m";
+}
+
+function log(...args: any[]): void {
+  const now = Date.now();
+  const elapsed = fmt_time(now - last_time);
+  last_time = now;
+  console.log(elapsed + "\t", ...args);
+}
+
+// TimeoutTask: runs a task in the future, cancels previous if rescheduled
+class TimeoutTask {
+  id: ReturnType<typeof setTimeout> | null = null;
+  task: ((schedule: (t?: number) => void) => void) | null;
+  time: number;
+
+  constructor(
+    task: ((schedule: (t?: number) => void) => void) | null,
+    time: number,
+  ) {
+    this.task = task;
+    this.time = time;
+  }
+
+  cancel(): void {
+    if (this.id !== null) {
+      clearTimeout(this.id);
+      this.id = null;
+    }
+  }
+
+  schedule(t?: number): void {
+    this.time = t !== undefined ? t : this.time;
+    this.cancel();
+    this.id = setTimeout(() => this.run(), this.time);
+  }
+
+  run(): void {
+    this.cancel();
+    if (this.task) this.task((t?: number) => this.schedule(t));
+  }
+}
+
+// TimeoutRAFTask: runs task on requestAnimationFrame
+class TimeoutRAFTask {
+  id: number | null = null;
+  task: ((next: () => void) => void) | null;
+
+  constructor(task: ((next: () => void) => void) | null) {
+    this.task = task;
+  }
+
+  cancel(): void {
+    if (this.id !== null) {
+      cancelAnimationFrame(this.id);
+      this.id = null;
+    }
+  }
+
+  run(): void {
+    if (this.task) {
+      this.cancel();
+      this.id = requestAnimationFrame(() => {
+        this.task!(() => this.run());
+      });
+    }
+  }
+}
+
+// TaskChecker: poll-based task runner
+class TaskChecker {
+  running = false;
+  task: ((schedule: (t?: number) => void) => void) | null;
+  time: number;
+  scheduled: number;
+
+  constructor(
+    task: ((schedule: (t?: number) => void) => void) | null,
+    time: number,
+  ) {
+    this.task = task;
+    this.time = time;
+    this.scheduled = Date.now() + time;
+  }
+
+  cancel(): void {
+    this.running = false;
+  }
+
+  schedule(t?: number): void {
+    this.running = true;
+    this.time = t !== undefined ? t : this.time;
+    this.scheduled = Date.now() + this.time;
+  }
+
+  run(): void {
+    if (this.task) this.task((t?: number) => this.schedule(t));
+  }
+
+  check(): void {
+    if (!this.running) return;
+    const now = Date.now();
+    if (now - this.scheduled >= 0) {
+      this.run();
+    }
+  }
+}
+
+// =============================================================================
+// GRAPHS (from app/js/graphs.js)
+// =============================================================================
+
+const PATH_DELIMITER = "/";
+
+function keys(d: any): string[] {
+  return getPath(d).map((v: any) => v.name);
+}
+
+function key(d: any): string {
+  return keys(d).join(PATH_DELIMITER);
+}
+
+function getPath(d: any): any[] {
+  const path = [d];
+  let node = d.parent;
+  while (node) {
+    path.unshift(node);
+    node = node.parent;
+  }
+  return path;
+}
+
+function getNodeFromPath(pathKeys: string[], root: any): any {
+  if (!pathKeys.length) {
+    log("warning no keys to navigate to");
+    return root;
+  }
+
+  let n = root;
+  let i = 0;
+  let name = pathKeys[i++];
+
+  if (i >= pathKeys.length) {
+    if (name !== n.name) {
+      log("warning, root name dont match!");
+    }
+    return n;
+  }
+
+  while (i < pathKeys.length && (name = pathKeys[i++])) {
+    const children = n.children
+      ? n.children.filter((c: any) => c.name === name)
+      : [];
+    if (!children[0]) return n;
+    n = children[0];
+  }
+
+  return n;
+}
+
+// =============================================================================
+// FILE EXTENSIONS (from app/js/file_extensions.js)
+// =============================================================================
+
+const extension_categories_11_raw: Record<string, string> = {
+  archive:
+    "7z,a,apk,ar,bz2,cab,cpio,deb,dmg,egg,gz,iso,jar,lha,mar,pea,rar,rpm,s7z,shar,tar,tbz2,tgz,tlz,war,whl,xpi,zip,zipx,deb,rpm,xz,pak,crx,exe,msi,bin",
+  audio:
+    "aac,aiff,ape,au,flac,gsm,it,m3u,m4a,mid,mod,mp3,mpa,pls,ra,s3m,sid,wav,wma,xm",
+  code: "c,cc,class,clj,cpp,cs,cxx,el,go,h,java,lua,m,m4,php,pl,po,py,rb,rs,sh,swift,vb,vcxproj,xcodeproj,xml,diff,patch",
+  font: "eot,otf,ttf,woff,woff2",
+  image:
+    "3dm,3ds,max,bmp,dds,gif,jpg,jpeg,png,psd,xcf,tga,thm,tif,tiff,yuv,ai,eps,ps,svg,dwg,dxf,gpx,kml,kmz,webp",
+  sheet: "ods,xls,xlsx,csv,ics,vcf",
+  slide: "ppt,odp",
+  text: "doc,docx,ebook,log,md,msg,odt,org,pages,pdf,rtf,rst,tex,txt,wpd,wps",
+  video:
+    "3g2,3gp,aaf,asf,avchd,avi,drc,flv,m2v,m4p,m4v,mkv,mng,mov,mp2,mp4,mpe,mpeg,mpg,mpv,mxf,nsv,ogg,ogv,ogm,qt,rm,rmvb,roq,srt,svi,vob,webm,wmv,yuv",
+  web: "html,htm,css,js,jsx,less,scss,wasm",
+};
+
+const extension_categories_6_raw: Record<string, string> = {
+  media:
+    "aac,au,flac,mid,midi,mka,mp3,mpc,ogg,opus,ra,wav,m4a,axa,oga,spx,xspf,mov,MOV,mpg,mpeg,m2v,mkv,ogm,mp4,m4v,mp4v,vob,qt,nuv,wmv,asf,rm,rmvb,flc,avi,fli,flv,gl,m2ts,divx,webm,axv,anx,ogv,ogx",
+  image:
+    "jpg,JPG,jpeg,gif,bmp,pbm,pgm,ppm,tga,xbm,xpm,tif,tiff,png,PNG,svg,svgz,mng,pcx,dl,xcf,xwd,yuv,cgm,emf,eps,CR2,ico",
+  code: "tex,rdf,owl,n3,ttl,nt,torrent,xml,*Makefile,*Rakefile,*Dockerfile,*build.xml,*rc,*1,nfo,*README,*README.txt,*readme.txt,md,*README.markdown,ini,yml,cfg,conf,h,hpp,c,cpp,cxx,cc,objc,sqlite,go,sql,csv",
+  archive:
+    "tar,tgz,arj,taz,lzh,lzma,tlz,txz,zip,z,Z,dz,gz,lz,xz,bz2,bz,tbz,tbz2,tz,deb,rpm,jar,rar,ace,zoo,cpio,7z,rz,apk,gem",
+  obj: "log,bak,aux,lof,lol,lot,out,toc,bbl,blg,*,part,incomplete,swp,tmp,temp,o,pyc,class,cache",
+  doc: "doc,docx,rtf,odt,dot,dotx,ott,xls,xlsx,ods,ots,ppt,pptx,odp,otp,fla,psd",
+};
+
+function build_reverse_map(
+  map: Record<string, string>,
+): Record<string, string> {
+  const reverse_map: Record<string, string> = {};
+  for (const type in map) {
+    map[type]
+      .split(",")
+      .map((e) => `.${e}`)
+      .forEach((k) => {
+        reverse_map[k] = type;
+      });
+  }
+  return reverse_map;
+}
+
+const extension_categories_11 = build_reverse_map(extension_categories_11_raw);
+const extension_categories_6 = build_reverse_map(extension_categories_6_raw);
+
+// =============================================================================
+// COLORS (from app/js/colors.js)
+// =============================================================================
+
+const size_scales = [0, 1e3, 1e5, 1e6, 1e8, 1e9, 1e12, 1e14, 1e15];
+
+const hue = d3Merged.scale.category10();
+
+const color_range = d3Merged.scale
+  .linear()
+  .range(["#000004", "#fcffa4"])
+  .interpolate(d3Merged.interpolateLab);
+
+const size_scale_colors = d3Merged.scale
+  .linear()
+  .domain(size_scales)
+  .clamp(true)
+  .range(["#000004", "#fcffa4"]);
+
+const depth_luminance = d3Merged.scale
+  .linear()
+  .domain([0, 11])
+  .clamp(true)
+  .range([75, 96]);
+
+const greyScale = d3Merged.scale
+  .linear()
+  .range(["black", "white"])
+  .domain([0, 12])
+  .clamp(true);
+
+// Seaborn palettes
+const SEABORN_DEEP = [
+  "#4C72B0",
+  "#DD8452",
+  "#55A868",
+  "#C44E52",
+  "#8172B3",
+  "#937860",
+  "#DA8BC3",
+  "#8C8C8C",
+  "#CCB974",
+  "#64B5CD",
+];
+const SEABORN_MUTED = [
+  "#4878D0",
+  "#EE854A",
+  "#6ACC64",
+  "#D65F5F",
+  "#956CB4",
+  "#8C613C",
+  "#DC7EC0",
+  "#797979",
+  "#D5BB67",
+  "#82C6E2",
+];
+const SEABORN_PASTEL = [
+  "#A1C9F4",
+  "#FFB482",
+  "#8DE5A1",
+  "#FF9F9B",
+  "#D0BBFF",
+  "#DEBB9B",
+  "#FAB0E4",
+  "#CFCFCF",
+  "#FFFEA3",
+  "#B9F2F0",
+];
+const SEABORN_BRIGHT = [
+  "#023EFF",
+  "#FF7C00",
+  "#1AC938",
+  "#E8000B",
+  "#8B2BE2",
+  "#9F4800",
+  "#F14CC1",
+  "#A3A3A3",
+  "#FFC400",
+  "#00D7FF",
+];
+const SEABORN_DARK = [
+  "#001C7F",
+  "#B1400D",
+  "#12711C",
+  "#8C0800",
+  "#591E71",
+  "#592F0D",
+  "#A23582",
+  "#3C3C3C",
+  "#B8850A",
+  "#006374",
+];
+const SEABORN_COLORBLIND = [
+  "#0173B2",
+  "#DE8F05",
+  "#029E73",
+  "#D55E00",
+  "#CC78BC",
+  "#CA9161",
+  "#FBAFE4",
+  "#949494",
+  "#ECE133",
+  "#56B4E9",
+];
+
+const CATEGORY_TO_INDEX_11: Record<string, number> = {
+  code: 0,
+  video: 1,
+  audio: 2,
+  archive: 3,
+  image: 4,
+  font: 5,
+  slide: 6,
+  sheet: 7,
+  text: 8,
+  web: 9,
+};
+
+const CATEGORY_TO_INDEX_6: Record<string, number> = {
+  code: 0,
+  media: 1,
+  image: 4,
+  archive: 3,
+  doc: 2,
+  obj: 7,
+};
+
+const seabornCache: Record<string, any> = {};
+let currentSeabornPalette = SEABORN_DEEP;
+let currentPaletteName = "deep";
+
+function setSeabornPalette(name: string): void {
+  const palettes: Record<string, string[]> = {
+    deep: SEABORN_DEEP,
+    muted: SEABORN_MUTED,
+    pastel: SEABORN_PASTEL,
+    bright: SEABORN_BRIGHT,
+    dark: SEABORN_DARK,
+    colorblind: SEABORN_COLORBLIND,
+  };
+  if (palettes[name]) {
+    currentSeabornPalette = palettes[name];
+    currentPaletteName = name;
+    Object.keys(seabornCache).forEach((k) => delete seabornCache[k]);
+  }
+}
+
+function hashString(s: string): number {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function schemeSeabornHash(ext: string): any {
+  const cacheKey = `${currentPaletteName}_hash_${ext}`;
+  if (seabornCache[cacheKey]) return seabornCache[cacheKey];
+
+  const index = hashString(ext) % currentSeabornPalette.length;
+  const hex = currentSeabornPalette[index];
+  const lab = d3Merged.lab(hex);
+  seabornCache[cacheKey] = lab;
+  return lab;
+}
+
+function schemeSeaborn11(ext: string): any {
+  const cacheKey = `${currentPaletteName}_11_${ext}`;
+  if (seabornCache[cacheKey]) return seabornCache[cacheKey];
+
+  if (ext in extension_categories_11) {
+    const category = extension_categories_11[ext];
+    const index = CATEGORY_TO_INDEX_11[category];
+    if (index !== undefined) {
+      const hex = currentSeabornPalette[index % currentSeabornPalette.length];
+      const lab = d3Merged.lab(hex);
+      seabornCache[cacheKey] = lab;
+      return lab;
+    }
+  }
+  return schemeSeabornHash(ext);
+}
+
+function schemeSeaborn6(ext: string): any {
+  const cacheKey = `${currentPaletteName}_6_${ext}`;
+  if (seabornCache[cacheKey]) return seabornCache[cacheKey];
+
+  if (ext in extension_categories_6) {
+    const category = extension_categories_6[ext];
+    const index = CATEGORY_TO_INDEX_6[category];
+    if (index !== undefined) {
+      const hex = currentSeabornPalette[index % currentSeabornPalette.length];
+      const lab = d3Merged.lab(hex);
+      seabornCache[cacheKey] = lab;
+      return lab;
+    }
+  }
+  return schemeSeabornHash(ext);
+}
+
+// Dark mode
+let isDarkMode = localStorage.getItem("dark_mode") === "true";
+
+function toggleDarkMode(enabled: any): void {
+  isDarkMode = !!enabled;
+  localStorage.setItem("dark_mode", enabled ? "true" : "false");
+
+  if (enabled) {
+    document.body.classList.add("dark-mode");
+  } else {
+    document.body.classList.remove("dark-mode");
+  }
+
+  if (PluginManager.data) {
+    State.showWorking((done: () => void) => {
+      PluginManager.cleanup();
+      PluginManager.loadLast();
+      done();
+    });
+  }
+}
+
+if (isDarkMode) {
+  document.body.classList.add("dark-mode");
+}
+
+// Legacy schemes
+const ext_reg = /\.\w+$/;
+const randExt: Record<string, string> = {};
+
+function schemeHue(ext: string): any {
+  if (!randExt[ext]) {
+    const h = hashString(ext) % 360;
+    const color = d3Merged.hsl(h, 0.8, 0.52);
+    randExt[ext] = color.toString();
+  }
+  return d3Merged.lab(randExt[ext]);
+}
+
+function schemeCat6(ext: string): any {
+  if (ext in extension_categories_6) {
+    return d3Merged.lab(hue(extension_categories_6[ext]));
+  }
+}
+
+function schemeCat11(ext: string): any {
+  if (ext in extension_categories_11) {
+    return d3Merged.lab(hue(extension_categories_11[ext]));
+  }
+}
+
+// Color schemes map
+const COLOR_SCHEMES: Record<string, (ext: string) => any> = {
+  seabornDeep: (ext) => {
+    setSeabornPalette("deep");
+    return schemeSeaborn11(ext);
+  },
+  seabornMuted: (ext) => {
+    setSeabornPalette("muted");
+    return schemeSeaborn11(ext);
+  },
+  seabornPastel: (ext) => {
+    setSeabornPalette("pastel");
+    return schemeSeaborn11(ext);
+  },
+  seabornBright: (ext) => {
+    setSeabornPalette("bright");
+    return schemeSeaborn11(ext);
+  },
+  seabornDark: (ext) => {
+    setSeabornPalette("dark");
+    return schemeSeaborn11(ext);
+  },
+  seabornColorblind: (ext) => {
+    setSeabornPalette("colorblind");
+    return schemeSeaborn11(ext);
+  },
+  schemeCat6,
+  schemeCat11,
+  schemeHue,
+};
+
+// Color by extension
+function byExtension(d: any, def?: boolean): any {
+  const m = ext_reg.exec(d.name);
+  const ext = m && m[0];
+  if (ext) {
+    return colorScheme(ext);
+  }
+  return def ? null : d3Merged.rgb(0, 0, 0);
+}
+
+// Color mode functions
+function colorByProp(d: any): any {
+  return d.color;
+}
+
+const size_luminance = d3Merged.scale
+  .linear()
+  .domain([0, 1e9])
+  .clamp(true)
+  .range([90, 50]);
+
+function colorBySizeBw(d: any): any {
+  const c = d3Merged.lab(0, 0, 0);
+  c.l = size_luminance(d.value);
+  return c;
+}
+
+const size_luminance2 = d3Merged.scale
+  .linear()
+  .domain([0, 1e9])
+  .clamp(true)
+  .range([50, 90]);
+
+function colorBySize(d: any): any {
+  const c = d3Merged.lab(size_scale_colors(d.value));
+  c.l = size_luminance2(d.value);
+  return c;
+}
+
+function getParent(d: any): any {
+  let p = d;
+  while (p.depth > 1) p = p.parent;
+  return p;
+}
+
+const colorByParentCache = new WeakMap();
+
+function colorByParent(d: any): any {
+  if (colorByParentCache.has(d)) {
+    return colorByParentCache.get(d);
+  }
+  const p = getParent(d);
+  const c = d3Merged.lab(hue(p.count));
+  c.l = depth_luminance(d.depth);
+  colorByParentCache.set(d, c);
+  return c;
+}
+
+function colorByParentName(d: any): any {
+  const p = getParent(d);
+  const c = d3Merged.lab(hue(p.name));
+  c.l = size_luminance(d.sum || d.value);
+  return c;
+}
+
+function colorByRandom(d: any): any {
+  const str = (d.name || "") + "|" + (d.depth || 0) + "|" + (d.value || 0);
+  const hash = hashString(str);
+  const index = hash % currentSeabornPalette.length;
+  const hex = currentSeabornPalette[index];
+  const c = d3Merged.lab(hex);
+  const lightnessVariation = ((hash >> 8) % 30) - 15;
+  c.l = Math.max(25, Math.min(85, c.l + lightnessVariation));
+  return c;
+}
+
+const COLOR_MODES: Record<string, (d: any) => any> = {
+  colorByProp,
+  colorBySizeBw,
+  colorBySize,
+  colorByParentName,
+  colorByParent,
+  colorByRandom,
+};
+
+let colorScheme =
+  COLOR_SCHEMES[localStorage.getItem("color_extension_scheme") || ""] ||
+  COLOR_SCHEMES.seabornPastel;
+let fill =
+  COLOR_MODES[localStorage.getItem("color_mode") || ""] || colorByParent;
+
+function switchColorMode(type: string): void {
+  fill = COLOR_MODES[type] || colorByProp;
+  localStorage.setItem("color_mode", type);
+  PluginManager.navigateTo(Navigation.currentPath());
+
+  if (PluginManager.data) {
+    State.showWorking((done: () => void) => {
+      PluginManager.cleanup();
+      PluginManager.loadLast();
+      done();
+    });
+  }
+}
+
+function switchColorScheme(scheme: string): void {
+  localStorage.setItem("color_extension_scheme", scheme);
+  colorScheme = COLOR_SCHEMES[scheme] || COLOR_SCHEMES.seabornDeep;
+  switchColorMode("colorByProp");
+}
+
+// Tree coloring
+function colorWalkNode(node: any): void {
+  const color = byExtension(node, true);
+  if (color) {
+    node.color = color;
+    return;
+  }
+
+  const { children } = node;
+  const len = children && children.length;
+  if (!children || !len) {
+    node.color = d3Merged.lab(65, 5, 10);
+    return;
+  }
+
+  const v = node.sum;
+  let l = 0,
+    a = 0,
+    b = 0;
+
+  for (let i = 0; i < len; i++) {
+    const child = children[i];
+    const clr = child.color;
+    const weight = v ? child.sum / v : 1 / len;
+    l += clr.l * weight;
+    a += clr.a * weight;
+    b += clr.b * weight;
+  }
+
+  const chromaBoost = 1.15;
+  a = a * chromaBoost;
+  b = b * chromaBoost;
+  l = l * 0.97;
+  l = Math.max(Math.min(95, l), 15);
+
+  node.color = d3Merged.lab(l, a, b);
+}
+
+function childrenFirst(data: any, func: (d: any) => void): void {
+  const { children } = data;
+  if (children) {
+    children.forEach((v: any) => childrenFirst(v, func));
+  }
+  func(data);
+}
+
+function colorByTypes(data: any): void {
+  childrenFirst(data, colorWalkNode);
+}
+
+// =============================================================================
+// DATA PROCESSING (from app/js/data.js)
+// =============================================================================
+
+let partition: any;
+
+function one(): number {
+  return 1;
+}
+
+function sizeValue(d: any): number {
+  return d.size;
+}
+
+function countIsValue(d: any): void {
+  d.count = d.value;
+}
+
+function sumAndHideChildren(d: any): void {
+  d._children = d.children;
+  d.sum = d.value;
+}
+
+function computeNodeCount(data: any): void {
+  console.time("computeNodeCount");
+  partition.value(one).nodes(data).forEach(countIsValue);
+  console.timeEnd("computeNodeCount");
+}
+
+function computeNodeSize(data: any): void {
+  console.time("computeNodeSize");
+  partition.value(sizeValue).nodes(data).forEach(sumAndHideChildren);
+  console.timeEnd("computeNodeSize");
+}
+
+function setNodeFilter(data: any): any {
+  const LEVELS = 11;
+  const HIDE_THRESHOLD = 0.1;
+
+  return partition.children(function hideChildren(d: any, depth: number) {
+    if (depth >= LEVELS) return null;
+    if (!d._children) return null;
+
+    const visibleChildren: any[] = [];
+    const hiddenChildren: any[] = [];
+
+    d._children.forEach((c: any) => {
+      if ((c.sum / d.sum) * 100 > HIDE_THRESHOLD) {
+        visibleChildren.push(c);
+      } else {
+        hiddenChildren.push(c);
+      }
+    });
+
+    if (hiddenChildren.length > 0) {
+      let otherSum = 0;
+      let otherCount = 0;
+      hiddenChildren.forEach((c: any) => {
+        otherSum += c.sum;
+        otherCount += c.count;
+      });
+
+      const otherNode = {
+        name: `Other files (${hiddenChildren.length} items)`,
+        sum: otherSum,
+        count: otherCount,
+        size: otherSum,
+        value: otherSum,
+        depth: d.depth + 1,
+        parent: d,
+        _children: null,
+        children: null,
+        _isOtherFiles: true,
+        color: d3Merged.lab(85, 0, 0),
+      };
+      visibleChildren.push(otherNode);
+    }
+
+    return visibleChildren;
+  });
+}
+
+function namesort(a: any, b: any): number {
+  return d3Merged.ascending(a.name, b.name);
+}
+
+// =============================================================================
+// CHART BASE (from app/js/chart.js)
+// =============================================================================
+
+class Chart {
+  resize(): void {}
+  generate(_data: any): void {}
+  navigateTo(_path: string[], _current?: any, _root?: any): void {}
+  showMore(): void {}
+  showLess(): void {}
+  cleanup(): void {}
+  highlightPath?(_path?: string[] | null, _node?: any, _root?: any): void;
+}
+
+// =============================================================================
+// SUNBURST (from app/js/sunburst.js)
+// =============================================================================
+
+function SunBurst() {
+  let LEVELS = 11;
+  const INNER_LEVEL = 7;
+  const USE_COUNT = 0;
+  const ANIMATION_DURATION = 300;
+
+  let rootNode: any = null;
+  let currentNode: any = null;
+  let hoveredNode: any = null;
+  let canvas: HTMLCanvasElement;
+  let ctx: CanvasRenderingContext2D;
+  let width: number, height: number, centerX: number, centerY: number;
+  let radius: number,
+    CORE_RADIUS: number,
+    OUTER_RADIUS: number,
+    FLEXI_LEVEL: number;
+
+  let visibleNodes: any[] = [];
+  let animationStart: number | null = null;
+  let isAnimating = false;
+
+  const drawer = new TimeoutRAFTask(draw);
+
+  let core_top: HTMLElement | null;
+  let core_center: HTMLElement | null;
+  let core_tag: HTMLElement | null;
+
+  function init() {
+    canvas = document.getElementById("sunburst-canvas") as HTMLCanvasElement;
+    if (!canvas) {
+      console.error("[sunburst] Canvas element not found");
+      return;
+    }
+    ctx = canvas.getContext("2d")!;
+
+    core_top = document.getElementById("core_top");
+    core_center = document.getElementById("core_center");
+    core_tag = document.getElementById("core_tag");
+
+    canvas.addEventListener("mousemove", onMouseMove);
+    canvas.addEventListener("mouseout", onMouseOut);
+    canvas.addEventListener("click", onClick);
+
+    const explanation = document.getElementById("explanation");
+    if (explanation) {
+      explanation.addEventListener("click", () => {
+        if (currentNode && currentNode.parent) {
+          State.navigateTo(keys(currentNode.parent));
+        }
+      });
+    }
+
+    calcDimensions();
+  }
+
+  function calcDimensions() {
+    const header = document.querySelector("header");
+    const footer = document.querySelector("footer");
+
+    width = window.innerWidth;
+    height =
+      window.innerHeight -
+      (header ? header.getBoundingClientRect().height : 0) -
+      (footer ? footer.getBoundingClientRect().height : 0);
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = width + "px";
+    canvas.style.height = height + "px";
+
+    centerX = width / 2;
+    centerY = height / 2;
+
+    const len = Math.min(width, height);
+    radius = len * 0.45;
+    CORE_RADIUS = radius * 0.4;
+    OUTER_RADIUS = radius - CORE_RADIUS;
+    FLEXI_LEVEL = Math.min(LEVELS, INNER_LEVEL);
+  }
+
+  function draw(next: () => void) {
+    if (!canvas || !ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    ctx.save();
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, width, height);
+
+    let t = 1;
+    if (isAnimating && animationStart) {
+      const elapsed = Date.now() - animationStart;
+      t = Math.min(elapsed / ANIMATION_DURATION, 1);
+      t = easeOutCubic(t);
+      if (t >= 1) {
+        isAnimating = false;
+        animationStart = null;
+      }
+    }
+
+    for (let i = 0; i < visibleNodes.length; i++) {
+      drawArc(visibleNodes[i], t);
+    }
+
+    drawCenter();
+    ctx.restore();
+
+    if (isAnimating) next();
+  }
+
+  function drawArc(node: any, t: number) {
+    const d = node.data;
+
+    const startAngle = lerp(node.fromStartAngle, node.startAngle, t);
+    const endAngle = lerp(node.fromEndAngle, node.endAngle, t);
+    const innerR = lerp(node.fromInnerR, node.innerR, t);
+    const outerR = lerp(node.fromOuterR, node.outerR, t);
+
+    if (endAngle - startAngle < 0.002) return;
+    if (outerR - innerR < 1) return;
+
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, outerR, startAngle, endAngle);
+    ctx.arc(centerX, centerY, innerR, endAngle, startAngle, true);
+    ctx.closePath();
+
+    let color;
+    if (d._isFreeSpace) {
+      color = "#e8e8e8";
+    } else {
+      color = fill(d);
+    }
+
+    if (color && typeof color.toString === "function") {
+      ctx.fillStyle = color.toString();
+    } else if (color) {
+      ctx.fillStyle = color;
+    } else {
+      ctx.fillStyle = "#888";
+    }
+
+    if (hoveredNode) {
+      ctx.globalAlpha = isAncestorOrDescendant(d, hoveredNode) ? 1 : 0.3;
+    } else {
+      ctx.globalAlpha = 0.85;
+    }
+
+    ctx.fill();
+
+    ctx.globalAlpha = 0.6;
+    ctx.strokeStyle = "#c8c8c8";
+    ctx.lineWidth = Math.max(0.25, 1.0 - (d.depth - currentNode.depth) * 0.08);
+    ctx.stroke();
+
+    ctx.globalAlpha = 1;
+  }
+
+  function drawCenter() {
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, CORE_RADIUS, 0, Math.PI * 2);
+    ctx.fillStyle = hoveredNode
+      ? "rgba(238, 238, 238, 0.5)"
+      : "rgba(238, 238, 238, 0.2)";
+    ctx.fill();
+    ctx.strokeStyle = "#ddd";
+    ctx.lineWidth = 1;
+    ctx.stroke();
+  }
+
+  function hitTest(mouseX: number, mouseY: number): any {
+    const dx = mouseX - centerX;
+    const dy = mouseY - centerY;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    const angle = Math.atan2(dy, dx);
+
+    if (distance <= CORE_RADIUS) {
+      return { type: "center", node: currentNode };
+    }
+
+    for (let i = visibleNodes.length - 1; i >= 0; i--) {
+      const node = visibleNodes[i];
+      if (distance >= node.innerR && distance <= node.outerR) {
+        const nodeStart = normalizeAngle(node.startAngle);
+        const nodeEnd = normalizeAngle(node.endAngle);
+        const testAngle = normalizeAngle(angle);
+
+        let inArc = false;
+        if (nodeStart <= nodeEnd) {
+          inArc = testAngle >= nodeStart && testAngle <= nodeEnd;
+        } else {
+          inArc = testAngle >= nodeStart || testAngle <= nodeEnd;
+        }
+
+        if (inArc) return { type: "arc", node: node.data };
+      }
+    }
+    return null;
+  }
+
+  function normalizeAngle(angle: number): number {
+    while (angle < 0) angle += Math.PI * 2;
+    while (angle >= Math.PI * 2) angle -= Math.PI * 2;
+    return angle;
+  }
+
+  function onMouseMove(e: MouseEvent) {
+    if (!currentNode) return;
+    const rect = canvas.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+    const mouseY = e.clientY - rect.top;
+
+    const hit = hitTest(mouseX, mouseY);
+    const newHovered = hit ? hit.node : null;
+
+    if (newHovered !== hoveredNode) {
+      hoveredNode = newHovered;
+      if (hoveredNode) {
+        updateCore(hoveredNode);
+        State.highlightPath(keys(hoveredNode));
+      } else {
+        if (currentNode) updateCore(currentNode);
+        State.highlightPath();
+      }
+      scheduleDraw();
+    }
+  }
+
+  function onMouseOut() {
+    if (hoveredNode) {
+      hoveredNode = null;
+      if (currentNode) updateCore(currentNode);
+      State.highlightPath();
+      scheduleDraw();
+    }
+  }
+
+  function onClick(e: MouseEvent) {
+    if (!currentNode) return;
+    const rect = canvas.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left;
+    const mouseY = e.clientY - rect.top;
+
+    const hit = hitTest(mouseX, mouseY);
+    if (!hit) return;
+
+    if (hit.type === "center") {
+      if (currentNode && currentNode.parent) {
+        State.navigateTo(keys(currentNode.parent));
+      }
+    } else if (hit.type === "arc") {
+      let node = hit.node;
+      if (node._isOtherFiles || node._isFreeSpace) return;
+      if (node.depth - currentNode.depth > 1) {
+        node = node.parent;
+      }
+      if (node && (node._children || node.children)) {
+        State.navigateTo(keys(node));
+      }
+    }
+  }
+
+  function updateCore(d: any) {
+    if (!d) return;
+    const baseNode = currentNode || rootNode;
+    const percent = baseNode
+      ? ((d.sum / baseNode.sum) * 100).toFixed(2) + "%"
+      : "";
+
+    if (core_top) core_top.innerHTML = d.name || "";
+    if (core_center)
+      core_center.innerHTML = format(d.sum).split(" ").join("<br/>");
+    if (core_tag) core_tag.innerHTML = percent + "<br/>";
+  }
+
+  function zoom(node: any) {
+    if (!node) return;
+
+    const oldNodes = visibleNodes.slice();
+    const oldNodeMap = new Map<string, any>();
+    oldNodes.forEach((n) => oldNodeMap.set(key(n.data), n));
+
+    currentNode = node;
+    updateCore(node);
+    computeVisibleNodes(node);
+
+    visibleNodes.forEach((n) => {
+      const k = key(n.data);
+      const old = oldNodeMap.get(k);
+      if (old) {
+        n.fromStartAngle = old.startAngle;
+        n.fromEndAngle = old.endAngle;
+        n.fromInnerR = old.innerR;
+        n.fromOuterR = old.outerR;
+      } else {
+        const midAngle = (n.startAngle + n.endAngle) / 2;
+        n.fromStartAngle = midAngle;
+        n.fromEndAngle = midAngle;
+        n.fromInnerR = CORE_RADIUS;
+        n.fromOuterR = CORE_RADIUS;
+      }
+    });
+
+    isAnimating = true;
+    animationStart = Date.now();
+    scheduleDraw();
+  }
+
+  function computeVisibleNodes(node: any) {
+    if (!node) return;
+
+    setNodeFilter(node);
+    const nodes = partition.nodes(node).slice(1);
+
+    let maxDepth = 0;
+    nodes.forEach((n: any) => {
+      const relativeDepth = n.depth - node.depth;
+      if (relativeDepth > maxDepth) maxDepth = relativeDepth;
+    });
+
+    FLEXI_LEVEL = Math.min(LEVELS, INNER_LEVEL, maxDepth);
+    if (FLEXI_LEVEL < 1) FLEXI_LEVEL = 1;
+
+    visibleNodes = [];
+    const ADJUSTMENT = -Math.PI / 2;
+
+    nodes.forEach((d: any) => {
+      const relativeDepth = d.depth - node.depth;
+      if (relativeDepth > LEVELS || relativeDepth < 1) return;
+
+      let innerR =
+        CORE_RADIUS + (OUTER_RADIUS / FLEXI_LEVEL) * (relativeDepth - 1);
+      const outerR =
+        CORE_RADIUS + (OUTER_RADIUS / FLEXI_LEVEL) * relativeDepth - 1;
+
+      if (innerR < 0) innerR = 0;
+      if (outerR <= innerR) return;
+
+      visibleNodes.push({
+        data: d,
+        startAngle: d.x + ADJUSTMENT,
+        endAngle: d.x + d.dx + ADJUSTMENT - 0.005,
+        innerR,
+        outerR,
+        fromStartAngle: d.x + ADJUSTMENT,
+        fromEndAngle: d.x + d.dx + ADJUSTMENT - 0.005,
+        fromInnerR: innerR,
+        fromOuterR: outerR,
+      });
+    });
+
+    visibleNodes.sort((a: any, b: any) => a.data.depth - b.data.depth);
+  }
+
+  function generateSunburst(root: any) {
+    rootNode = root;
+    currentNode = root;
+
+    partition = d3Merged.layout.partition();
+    partition
+      .value((d: any) => d.size)
+      .sort(namesort)
+      .size([2 * Math.PI, radius]);
+
+    computeNodeCount(root);
+    computeNodeSize(root);
+
+    console.time("color");
+    colorByTypes(root);
+    console.timeEnd("color");
+
+    log("Root count", root.count, "ROOT size", format(root.value));
+
+    setNodeFilter(root).value((d: any) => (USE_COUNT ? d.count : d.sum));
+
+    computeVisibleNodes(root);
+    updateCore(root);
+
+    visibleNodes.forEach((n) => {
+      n.fromStartAngle = n.startAngle;
+      n.fromEndAngle = n.endAngle;
+      n.fromInnerR = n.innerR;
+      n.fromOuterR = n.outerR;
+    });
+
+    scheduleDraw();
+  }
+
+  function scheduleDraw() {
+    drawer.run();
+  }
+
+  function lerp(a: number, b: number, t: number): number {
+    return a + (b - a) * t;
+  }
+
+  function easeOutCubic(t: number): number {
+    return 1 - Math.pow(1 - t, 3);
+  }
+
+  function isAncestorOrDescendant(a: any, b: any): boolean {
+    if (!a || !b) return false;
+    let node: any = b;
+    while (node) {
+      if (node === a) return true;
+      node = node.parent;
+    }
+    node = a;
+    while (node) {
+      if (node === b) return true;
+      node = node.parent;
+    }
+    return false;
+  }
+
+  init();
+
+  return {
+    resize() {
+      calcDimensions();
+      if (currentNode) {
+        computeVisibleNodes(currentNode);
+        visibleNodes.forEach((n) => {
+          n.fromStartAngle = n.startAngle;
+          n.fromEndAngle = n.endAngle;
+          n.fromInnerR = n.innerR;
+          n.fromOuterR = n.outerR;
+        });
+        scheduleDraw();
+      }
+    },
+    generate: generateSunburst,
+    showMore() {
+      LEVELS++;
+      if (currentNode) {
+        computeVisibleNodes(currentNode);
+        visibleNodes.forEach((n) => {
+          n.fromStartAngle = n.startAngle;
+          n.fromEndAngle = n.endAngle;
+          n.fromInnerR = n.innerR;
+          n.fromOuterR = n.outerR;
+        });
+        scheduleDraw();
+      }
+    },
+    showLess() {
+      if (LEVELS <= 1) return;
+      LEVELS--;
+      if (currentNode) {
+        computeVisibleNodes(currentNode);
+        visibleNodes.forEach((n) => {
+          n.fromStartAngle = n.startAngle;
+          n.fromEndAngle = n.endAngle;
+          n.fromInnerR = n.innerR;
+          n.fromOuterR = n.outerR;
+        });
+        scheduleDraw();
+      }
+    },
+    cleanup() {
+      rootNode = null;
+      currentNode = null;
+      hoveredNode = null;
+      visibleNodes = [];
+      if (ctx) {
+        const dpr = window.devicePixelRatio || 1;
+        ctx.save();
+        ctx.scale(dpr, dpr);
+        ctx.clearRect(0, 0, width, height);
+        ctx.restore();
+      }
+    },
+    navigateTo(targetKeys: string[]) {
+      if (!rootNode) return;
+      const n = getNodeFromPath(targetKeys, rootNode);
+      if (n) zoom(n);
+    },
+    highlightPath(_path: string[] | null | undefined, node?: any) {
+      const newHovered = node || null;
+      if (newHovered !== hoveredNode) {
+        hoveredNode = newHovered;
+        if (hoveredNode) {
+          updateCore(hoveredNode);
+        } else if (currentNode) {
+          updateCore(currentNode);
+        }
+        scheduleDraw();
+      }
+    },
+  };
+}
+
+// =============================================================================
+// TREEMAP (from app/js/treemap.js)
+// =============================================================================
+
+function TreeMap() {
+  let width = window.innerWidth;
+  let height =
+    window.innerHeight -
+    (document.querySelector("header")?.getBoundingClientRect().height || 0) -
+    (document.querySelector("footer")?.getBoundingClientRect().height || 0);
+
+  let xd = d3Merged.scale.linear().domain([0, width]).range([0, width]);
+  let yd = d3Merged.scale.linear().domain([0, height]).range([0, height]);
+
+  let textHeight: number;
+
+  const drawer = new TimeoutRAFTask(draw);
+  const canceller = new TimeoutTask(() => {
+    drawer.cancel();
+  }, 500);
+
+  function drawThenCancel() {
+    drawer.run();
+    canceller.schedule();
+  }
+
+  function isPointInRect(
+    mx: number,
+    my: number,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+  ): boolean {
+    return mx >= x && mx <= x + w && my >= y && my <= y + h;
+  }
+
+  let treemap: any;
+
+  function mktreemap() {
+    treemap = d3Merged.layout
+      .treemap()
+      .round(false)
+      .sort((a: any, b: any) => a.value - b.value)
+      .value((d: any) => d.size);
+  }
+
+  mktreemap();
+
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+  const ctx = canvas.getContext("2d")!;
+
+  function onResize() {
+    width = window.innerWidth;
+    height =
+      window.innerHeight -
+      (document.querySelector("header")?.getBoundingClientRect().height || 0) -
+      (document.querySelector("footer")?.getBoundingClientRect().height || 0);
+
+    xd = d3Merged.scale.linear().domain([0, width]).range([0, width]);
+    yd = d3Merged.scale.linear().domain([0, height]).range([0, height]);
+
+    canvas.width = width * window.devicePixelRatio;
+    canvas.height = height * window.devicePixelRatio;
+    canvas.style.width = width + "px";
+    canvas.style.height = height + "px";
+
+    ctx.font = "10px Tahoma";
+    ctx.textBaseline = "top";
+    ctx.textAlign = "left";
+    const metrics = ctx.measureText("M");
+    textHeight = metrics.width;
+
+    if (currentNode) navigateTo(currentNode);
+  }
+
+  // FakeSVG: intermediate representation for d3 join pattern on canvas
+  class FakeSVG {
+    objects: any[] = [];
+    map = new Map<string, any>();
+    keyFn: (d: any) => string;
+    sorter: ((a: any, b: any) => number) | null = null;
+
+    constructor(keyFn: (d: any) => string) {
+      this.keyFn = keyFn;
+    }
+
+    data(data: any[]): any[] {
+      const map = this.map;
+      const enter: any[] = [];
+
+      this.objects.forEach((o) => (o.__remove__ = true));
+
+      for (let i = 0, il = data.length; i < il; i++) {
+        const d = data[i];
+        const k = this.keyFn(d);
+        let o;
+        if (!map.has(k)) {
+          o = {};
+          enter.push(o);
+          map.set(k, o);
+        }
+        o = map.get(k);
+        o.__data__ = d;
+        o.__remove__ = false;
+      }
+
+      this.updateObjects();
+      return enter;
+    }
+
+    sort(func?: (a: any, b: any) => number) {
+      if (func) this.sorter = func;
+      if (this.sorter) this.objects.sort(this.sorter);
+    }
+
+    updateObjects() {
+      this.objects = [...this.map.values()];
+    }
+  }
+
+  const fake_svg = new FakeSVG(key);
+  let nnn: any;
+
+  let USE_GAP = 0;
+  let USE_BORDERS = 1;
+  let TREEMAP_LEVELS = 2;
+  const BENCH = 0;
+  let mouseclicked: boolean;
+  let mousex = -1;
+  let mousey = -1;
+  let mouseovered: any = null;
+  let highlightNode: any = null;
+  let currentDepth = 0;
+  let currentNode: any;
+  let rootNode: any;
+  let zooming = false;
+  let full_repaint = true;
+
+  onResize();
+
+  function display(data: any, relayout?: boolean) {
+    log("display", data);
+
+    console.time("treemap");
+    let nodes;
+    if (!nnn || relayout) {
+      nodes = treemap.nodes(data);
+    }
+
+    const total_size = data.value;
+    nodes = walk(data, null, currentDepth + TREEMAP_LEVELS + 1);
+    console.timeEnd("treemap");
+
+    console.time("filter");
+    nnn = nodes.filter(
+      (d: any) =>
+        d.depth >= currentDepth &&
+        d.depth <= currentDepth + TREEMAP_LEVELS + 1 &&
+        d.value / total_size > 0.000001,
+    );
+    console.timeEnd("filter");
+
+    const enter = fake_svg.data(nnn);
+    enter.forEach(rectDrawNoAnimate);
+
+    xd.domain([data.x, data.x + data.dx]);
+    yd.domain([data.y, data.y + data.dy]);
+
+    fake_svg.objects.forEach(rectDrawAnimate);
+
+    fake_svg.sort((a: any, b: any) => a.__data__.depth - b.__data__.depth);
+
+    drawThenCancel();
+  }
+
+  function gx(d: any): number {
+    return xd(d.x);
+  }
+  function gy(d: any): number {
+    return yd(d.y);
+  }
+  function gw(d: any): number {
+    return xd(d.x + d.dx) - xd(d.x);
+  }
+  function gh(d: any): number {
+    return yd(d.y + d.dy) - yd(d.y);
+  }
+
+  function rectDrawAnimate(g: any) {
+    rectDraw(g, true);
+  }
+  function rectDrawNoAnimate(g: any) {
+    rectDraw(g, false);
+  }
+
+  function rectDraw(g: any, animate: boolean) {
+    const d = g.__data__;
+
+    let x = xd(d.x);
+    let y = yd(d.y);
+    let w = xd(d.x + d.dx) - xd(d.x);
+    let h = yd(d.y + d.dy) - yd(d.y);
+
+    const depthDiff = d.depth - currentDepth;
+    const labelAdjustment = textHeight * 1.4;
+
+    const chain = [d];
+    const ry: number[] = [];
+    for (let i = 0, n = d; i < depthDiff; i++) {
+      const p = n.parent;
+      if (!p) break;
+      chain.push(p);
+      ry.push(gy(n) - gy(p));
+      n = p;
+    }
+
+    let p = chain.pop();
+    if (p) {
+      h = gh(p);
+      const parentHeight = p.parent ? gh(p.parent) : height;
+      let ny = (gy(p) / parentHeight) * (parentHeight - labelAdjustment);
+      for (let i = chain.length; i--; ) {
+        const n = chain[i];
+        ny += (ry[i] / gh(p)) * (h - labelAdjustment);
+        h = (gh(n) / gh(p)) * (h - labelAdjustment);
+        p = n;
+      }
+      y = ny + labelAdjustment * depthDiff;
+    }
+
+    if (animate) {
+      const now = Date.now();
+      const end = now + 400;
+      const trans: any = (g.__transition__ = {
+        timeStart: now,
+        timeEnd: end,
+        ease: d3Merged.easeCubic,
+        props: {},
+      });
+      transition(trans.props, "x", g, x);
+      transition(trans.props, "y", g, y);
+      transition(trans.props, "w", g, w);
+      transition(trans.props, "h", g, h);
+    } else {
+      g.x = x;
+      g.y = y;
+      g.h = h;
+      g.w = w;
+    }
+  }
+
+  function transition(trans: any, prop: string, graphic: any, value: number) {
+    if (prop in graphic) {
+      trans[prop] = { valueStart: graphic[prop], valueEnd: value };
+    } else {
+      graphic[prop] = value;
+    }
+  }
+
+  function draw(next: (t?: number) => void) {
+    if (BENCH) console.time("canvas draw");
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    let dom = fake_svg.objects;
+
+    const found: any[] = [];
+    const hover: any[] = [];
+
+    ctx.save();
+    const dpr = window.devicePixelRatio;
+    ctx.scale(dpr, dpr);
+
+    let needSvgUpdate = false;
+
+    // Update animation
+    dom.forEach((g: any) => {
+      const d = g.__data__;
+      const trans = g.__transition__;
+      if (trans) {
+        const now = Date.now();
+        const dur = trans.timeEnd - trans.timeStart;
+        const lapse = now - trans.timeStart;
+        const k = Math.min(lapse / dur, 1);
+        const ease = trans.ease;
+
+        const props = trans.props;
+        for (const pk in props) {
+          const prop = props[pk];
+          const diff = prop.valueEnd - prop.valueStart;
+          g[pk] = ease(k) * diff + prop.valueStart;
+        }
+
+        if (now >= trans.timeEnd) {
+          delete g.__transition__;
+          if (g.__remove__) {
+            fake_svg.map.delete(fake_svg.keyFn(d));
+            needSvgUpdate = true;
+          }
+        }
+      }
+    });
+
+    if (needSvgUpdate) {
+      fake_svg.updateObjects();
+      fake_svg.sort();
+      dom = fake_svg.objects;
+    }
+
+    dom.forEach((g: any) => {
+      const data = g.__data__;
+      if (data.depth < currentDepth) return;
+
+      const l = data.parent === mouseovered ? 1 : 0;
+      if (data.depth > TREEMAP_LEVELS + currentDepth + l) return;
+
+      ctx.save();
+
+      const x = g.x;
+      const y = g.y;
+      const w = g.w;
+      const h = g.h;
+
+      if (mouseovered || highlightNode) ctx.globalAlpha = 0.4;
+      else ctx.globalAlpha = 0.95;
+
+      if (w < 0.5 || h < 0.5) {
+        ctx.restore();
+        return;
+      }
+
+      ctx.beginPath();
+      ctx.rect(x, y, w, h);
+      ctx.fillStyle = fill(data);
+
+      let inHighlight = false;
+      if (highlightNode) {
+        let p = data;
+        while (p.depth > highlightNode.depth) p = p.parent;
+        inHighlight = p === highlightNode;
+      }
+
+      const inRect = isPointInRect(mousex, mousey, x, y, w, h);
+
+      if (inHighlight) {
+        ctx.globalAlpha = 1;
+      } else if (inRect) {
+        ctx.globalAlpha = data === mouseovered ? 1 : 0.5;
+      }
+
+      if (inRect) {
+        if (data.depth <= currentDepth + TREEMAP_LEVELS) {
+          hover.push(data);
+        }
+        if (mouseclicked) found.push(data);
+      }
+
+      ctx.fill();
+
+      if (USE_BORDERS) {
+        ctx.strokeStyle = "#eee";
+        ctx.stroke();
+      }
+
+      if (w > 70) {
+        ctx.clip();
+        ctx.fillStyle = "#333";
+        ctx.fillText(data.name + " " + format(data.value), x + 3, y);
+      }
+
+      ctx.restore();
+    });
+
+    ctx.restore();
+
+    if (BENCH) console.timeEnd("canvas draw");
+    if (hover.length) mouseovered = hover[hover.length - 1];
+    if (mouseovered) {
+      State.highlightPath(keys(mouseovered));
+    }
+    mouseclicked = false;
+
+    if (found.length) {
+      const d = found[hover.length - 1];
+      const to = d.children ? d : d.parent;
+      State.navigateTo(keys(to));
+    }
+
+    full_repaint = false;
+    next(100);
+  }
+
+  // Canvas mouse events
+  d3Merged
+    .select(canvas)
+    .on("mousemove", function () {
+      [mousex, mousey] = d3Merged.mouse(canvas);
+      drawThenCancel();
+    })
+    .on("mouseout", function () {
+      mouseovered = null;
+      State.highlightPath(null);
+      mousex = -1;
+      mousey = -1;
+    })
+    .on("click", function () {
+      mouseclicked = true;
+      drawThenCancel();
+    });
+
+  function navigateTo(d: any) {
+    if (!d || !d.children) return;
+    full_repaint = true;
+    currentDepth = d.depth;
+    currentNode = d;
+    highlightNode = null;
+    zoomTo(d);
+  }
+
+  function walk(node: any, a: any[] | null, maxDepth: number): any[] {
+    a = a ? a : [node];
+    if (node.depth < maxDepth && node.children) {
+      for (let i = 0, len = node.children.length; i < len; i++) {
+        a.push(node.children[i]);
+        walk(node.children[i], a, maxDepth);
+      }
+    }
+    return a;
+  }
+
+  function zoomTo(d: any) {
+    if (zooming || !d) return;
+    zooming = true;
+    display(d);
+    zooming = false;
+  }
+
+  function generateTreemap(data: any) {
+    rootNode = data;
+    log("generateTreemap", rootNode);
+
+    let oldPath: string[] | undefined;
+    if (currentNode) oldPath = keys(currentNode);
+
+    colorByTypes(rootNode);
+
+    currentNode = rootNode;
+    currentDepth = 0;
+    display(rootNode, true);
+
+    if (oldPath) navigateToPath(oldPath);
+  }
+
+  function navigateToPath(pathKeys: string[]) {
+    const n = getNodeFromPath(pathKeys, rootNode);
+    if (n) navigateTo(n);
+  }
+
+  function showMore() {
+    TREEMAP_LEVELS++;
+    zoomTo(currentNode);
+  }
+
+  function showLess() {
+    if (TREEMAP_LEVELS > 1) TREEMAP_LEVELS--;
+    zoomTo(currentNode);
+  }
+
+  return {
+    generate: generateTreemap,
+    showLess,
+    showMore,
+    resize: onResize,
+    cleanup() {
+      rootNode = null;
+      currentNode = null;
+    },
+    navigateTo: navigateToPath,
+    highlightPath(_path: string[] | null | undefined, node?: any) {
+      highlightNode = node;
+      drawThenCancel();
+    },
+  };
+}
+
+// =============================================================================
+// FLAMEGRAPH (from app/js/flamegraph.js)
+// =============================================================================
+
+function getFlameNodePath(node: any): string[] {
+  const fullname: string[] = [];
+  while (node.parent) {
+    fullname.push(node.data.name);
+    node = node.parent;
+  }
+  fullname.push(node.data.name);
+  return fullname.reverse();
+}
+
+class FlameGraph extends Chart {
+  chart: any;
+  graph: any;
+  data: any = null;
+  currentPath: string = "";
+
+  constructor() {
+    super();
+    this.chart = d3Merged.select("#flame-chart");
+
+    this.graph = flamegraph()
+      .height(400)
+      .width(460)
+      .cellHeight(20)
+      .transitionDuration(350)
+      .transitionEase(d3Merged.easeCubic);
+
+    const tip = defaultFlamegraphTooltip().text((d: any) => {
+      const fullpath = getFlameNodePath(d).join("/");
+      return (
+        fullpath +
+        " - " +
+        format(d.data.value) +
+        " " +
+        `(${((d.data.value / this.data.value) * 100).toFixed(2)}%)`
+      );
+    });
+
+    this.graph.tooltip(tip).onClick((e: any) => {
+      if (e) {
+        const movingTo = getFlameNodePath(e).join("/");
+        const route = Navigation.currentPath().join("/");
+        if (route !== movingTo) {
+          console.log("movingTo", movingTo, route);
+        }
+        this.currentPath = movingTo;
+        State.navigateTo(getFlameNodePath(e));
+      }
+    });
+  }
+
+  resize() {
+    const w = globalWidth || window.innerWidth;
+    const h = globalHeight || window.innerHeight - 200;
+    const newHeight = (h * 2) / 3;
+    this.graph.width(w).height(newHeight);
+    const svg = document.querySelector(".d3-flame-graph");
+    if (svg) {
+      svg.setAttribute("width", String(w));
+      svg.setAttribute("height", String(newHeight));
+    }
+    this.draw();
+  }
+
+  draw() {
+    if (!this.data) return;
+    this.chart.datum(this.data).call(this.graph);
+  }
+
+  navigateTo(path: string[]) {
+    if (path.join("/") === this.currentPath) return;
+  }
+
+  generate(data: any) {
+    console.log("FlameGraph generate");
+
+    function computeValue(node: any): number {
+      if (node.children && node.children.length > 0) {
+        let sum = 0;
+        for (const child of node.children) {
+          sum += computeValue(child);
+        }
+        node.value = sum;
+        return sum;
+      } else {
+        node.value = node.size || 0;
+        return node.value;
+      }
+    }
+
+    const clonedData = JSON.parse(JSON.stringify(data));
+    computeValue(clonedData);
+
+    const THRESHOLD = 0.001;
+    const totalValue = clonedData.value || 1;
+
+    function filterSmallNodes(node: any): any {
+      if (node.children) {
+        node.children = node.children
+          .filter((child: any) => child.value / totalValue >= THRESHOLD)
+          .map(filterSmallNodes);
+      }
+      return node;
+    }
+
+    filterSmallNodes(clonedData);
+    this.data = clonedData;
+    this.draw();
+  }
+
+  cleanup() {
+    this.chart.selectAll("*").remove();
+  }
+}
+
+// =============================================================================
+// LISTVIEW (from app/js/listview.js)
+// =============================================================================
+
+function elm(
+  tag: string,
+  attrs?: Record<string, string>,
+  children?: string | HTMLElement | (string | HTMLElement)[],
+  props?: Record<string, any>,
+): HTMLElement {
+  const el = document.createElement(tag);
+  if (attrs) {
+    for (const k in attrs) {
+      el.setAttribute(k, attrs[k]);
+    }
+  }
+  if (children) {
+    const childArr = Array.isArray(children) ? children : [children];
+    for (let child of childArr) {
+      if (typeof child === "string") {
+        (child as any) = document.createTextNode(child);
+      }
+      el.appendChild(child as Node);
+    }
+  }
+  if (props) {
+    for (const k in props) {
+      (el as any)[k] = props[k];
+    }
+  }
+  return el;
+}
+
+const sidebar = document.getElementById("sidebar")!;
+
+class ListView extends Chart {
+  path: string[] | null = null;
+  current: any = null;
+  nodes: any[] = [];
+  highlightedPath: string[] | null = null;
+
+  navigateTo(path: string[], current: any) {
+    this.path = path;
+    this.current = current;
+
+    const nodes = current._children || current.children || [];
+    this.nodes = nodes.slice().sort((a: any, b: any) => {
+      const aVal = a.sum ?? a.value ?? a.size ?? 0;
+      const bVal = b.sum ?? b.value ?? b.size ?? 0;
+      if (aVal < bVal) return 1;
+      if (aVal > bVal) return -1;
+      return 0;
+    });
+
+    this.draw(this.path!, this.current);
+  }
+
+  draw(path: string[], current: any) {
+    if (!current) return;
+
+    const INITIAL_LOAD = 10;
+    const currentSize = current.sum ?? current.value ?? current.size ?? 0;
+
+    const navs: HTMLElement[] = [
+      elm(
+        "h5",
+        { class: "nav-group-title" },
+        `${path.join("/")} ${format(currentSize)}`,
+        {
+          onclick: () => State.navigateTo(path.slice(0, -1)),
+        },
+      ),
+    ];
+
+    const highlighted = this.highlightedPath;
+    const check_path =
+      highlighted &&
+      highlighted.length > path.length &&
+      !path.some((p, i) => p !== highlighted[i])
+        ? highlighted[path.length]
+        : null;
+
+    const nodes = this.nodes;
+    nodes.slice(0, INITIAL_LOAD).forEach((child: any) => {
+      const childSize = child.sum ?? child.value ?? child.size ?? 0;
+      navs.push(
+        elm(
+          "span",
+          {
+            class: `nav-group-item${check_path === child.name ? " active" : ""}`,
+            href: "#",
+          },
+          [
+            elm("span", {
+              class: "icon icon-record",
+              style: `color: ${fill(child)};`,
+            }),
+            child.name || "",
+            elm(
+              "span",
+              { class: "", style: "float:right;" },
+              format(childSize),
+            ),
+          ],
+          {
+            onmousedown: () => {
+              child.children && State.navigateTo([...path, child.name]);
+            },
+            onmouseenter: () => State.highlightPath([...path, child.name]),
+            onmouseleave: () => State.highlightPath(),
+          },
+        ),
+      );
+    });
+
+    const remaining = nodes.length - INITIAL_LOAD;
+    if (remaining > 0) {
+      navs.push(
+        elm("span", { class: "nav-group-item", href: "#" }, [
+          elm("span", { class: "icon icon-record" }),
+          `and ${remaining} other items....`,
+        ]),
+      );
+    }
+
+    [...sidebar.childNodes].forEach((v) => v.remove());
+    const nav = elm("nav", { class: "nav-group" }, navs);
+    sidebar.appendChild(nav);
+  }
+
+  highlightPath(path?: string[] | null) {
+    const oldHighlight = this.highlightedPath;
+    this.highlightedPath = path || null;
+
+    if (!this.path || !this.current) return;
+
+    const highlighted = path;
+    const check_path =
+      highlighted &&
+      highlighted.length > this.path.length &&
+      !this.path.some((p, i) => p !== highlighted![i])
+        ? highlighted[this.path.length]
+        : null;
+
+    const oldCheck =
+      oldHighlight &&
+      oldHighlight.length > this.path.length &&
+      !this.path.some((p, i) => p !== oldHighlight[i])
+        ? oldHighlight[this.path.length]
+        : null;
+
+    if (check_path !== oldCheck) {
+      const items = sidebar.querySelectorAll(".nav-group-item");
+      items.forEach((item) => {
+        const itemName = item.childNodes[1];
+        if (itemName && itemName.textContent === check_path) {
+          item.classList.add("active");
+        } else {
+          item.classList.remove("active");
+        }
+      });
+    }
+  }
+
+  cleanup() {
+    this.path = null;
+    this.current = null;
+    this.highlightedPath = null;
+  }
+}
+
+// =============================================================================
+// BREADCRUMBS (from app/js/breadcrumbs.js)
+// =============================================================================
+
+let selection: any = null;
+
+function updateSelection(s: any) {
+  selection = s;
+}
+
+function getAncestors(node: any): any[] {
+  if (!node) return [];
+  let path: any[] = [];
+  let current = node;
+  while (current.parent) {
+    path.unshift(current);
+    current = current.parent;
+  }
+
+  const root = current;
+
+  if (root.name === "/" || root.name.indexOf("/") === -1) {
+    path.unshift(root);
+  } else {
+    path = root.name
+      .split(PATH_DELIMITER)
+      .slice(1)
+      .map((d: string) => ({ name: d, depth: -1, root: true }))
+      .concat(path);
+  }
+
+  return path;
+}
+
+function _updateBreadcrumbs(nodeArray: any[]) {
+  const g = d3Merged
+    .select("#bottom_status")
+    .selectAll("span")
+    .data(nodeArray, (d: any) => d.name + d.depth);
+
+  const entering = g
+    .enter()
+    .append("span")
+    .style("-webkit-app-region", "no-drag")
+    .style("cursor", "pointer")
+    .on("click", (d: any) => {
+      log("navigate", d);
+      State.navigateTo(keys(d));
+    });
+
+  entering.text((d: any) => (nodeArray[0] === d ? "" : " > ") + d.name);
+
+  g.exit().remove();
+}
+
+class Breadcrumbs extends Chart {
+  trail: any[] = [];
+
+  navigateTo(_path: string[], d: any) {
+    if (!d) return;
+    this.trail = getAncestors(d);
+    _updateBreadcrumbs(this.trail);
+  }
+
+  highlightPath(_path?: string[] | null, d?: any) {
+    if (d) {
+      _updateBreadcrumbs(getAncestors(d));
+      updateSelection(d);
+    } else {
+      _updateBreadcrumbs(this.trail);
+      updateSelection(null);
+    }
+  }
+}
+
+// Context menu via RPC (replaces Electron remote.Menu)
+window.addEventListener(
+  "contextmenu",
+  async (e) => {
+    if (!selection) return;
+    e.preventDefault();
+
+    const items = [
+      { label: "Open Directory", action: "show-selection", enabled: true },
+      {
+        label: "Open File",
+        action: "open-selection",
+        enabled: !selection.children,
+      },
+      { label: "Delete", action: "trash-selection", enabled: true },
+    ];
+
+    try {
+      await electroview.rpc.request.showContextMenu({ items });
+    } catch (err) {
+      console.error("[renderer] Context menu error:", err);
+    }
+  },
+  false,
+);
+
+// =============================================================================
+// ROUTER (from app/js/router.js)
+// =============================================================================
+
+// Simple EventEmitter for NavigationController
+type EventHandler = (...args: any[]) => void;
+
+class SimpleEventEmitter {
+  private _handlers: Record<string, EventHandler[]> = {};
+
+  on(event: string, handler: EventHandler) {
+    if (!this._handlers[event]) this._handlers[event] = [];
+    this._handlers[event].push(handler);
+  }
+
+  emit(event: string, ...args: any[]) {
+    const handlers = this._handlers[event];
+    if (handlers) handlers.forEach((h) => h(...args));
+  }
+}
+
+class NavigationController extends SimpleEventEmitter {
+  backStack: string[][] = [];
+  fwdStack: string[][] = [];
+
+  constructor() {
+    super();
+    this.clear();
+  }
+
+  clear() {
+    this.backStack = [];
+    this.fwdStack = [];
+  }
+
+  currentPath(): string[] {
+    const { backStack } = this;
+    return backStack.length ? backStack[backStack.length - 1].concat() : [];
+  }
+
+  updatePath(path: string[]) {
+    if (!path.length) return;
+    if (this.currentPath().join("/") === path.join("/")) return;
+    this.backStack.push(path);
+    if (this.fwdStack.length) this.fwdStack = [];
+    this.notify();
+  }
+
+  notify() {
+    this.emit("navigationchanged", this.currentPath());
+  }
+
+  back() {
+    if (this.backStack.length < 2) return;
+    const n = this.backStack.pop()!;
+    log("navigateBack", n);
+    this.fwdStack.push(n);
+    this.notify();
+  }
+
+  forward() {
+    if (!this.fwdStack.length) return;
+    const n = this.fwdStack.pop()!;
+    this.backStack.push(n);
+    this.notify();
+  }
+}
+
+const Navigation = new NavigationController();
+
+const State = {
+  navigateTo: (path: string[]) => Navigation.updatePath(path),
+  clearNavigation: () => {
+    Navigation.clear();
+    PluginManager.clear();
+  },
+  highlightPath: (path?: string[] | null) => {
+    PluginManager.highlightPath(path);
+  },
+  showWorking: (func: (done: () => void) => void) => {
+    lightbox(true);
+    setTimeout(func, 100, () => lightbox(false));
+  },
+};
+
+// Global width/height (used by FlameGraph and others)
+let globalWidth: number;
+let globalHeight: number;
+
+function calculateDimensions() {
+  globalWidth = innerWidth;
+  globalHeight =
+    innerHeight -
+    (document.querySelector("header")?.getBoundingClientRect().height || 0) -
+    (document.querySelector("footer")?.getBoundingClientRect().height || 0);
+}
+
+// =============================================================================
+// PLUGIN MANAGER (from app/js/router.js)
+// =============================================================================
+
+class SpacePluginManager {
+  activatedGraphs = new Set<any>();
+  data: any = null;
+
+  resize() {
+    calculateDimensions();
+    this.activatedGraphs.forEach((g) => g.resize());
+  }
+
+  clear() {
+    this.data = null;
+  }
+
+  generate(json: any) {
+    const loaded = this.data;
+    this.data = json;
+
+    this.activatedGraphs.forEach((g) => g.generate(json));
+    this.resize();
+    if (!loaded) {
+      State.navigateTo([json.name]);
+    } else {
+      this.navigateTo(Navigation.currentPath());
+    }
+  }
+
+  navigateTo(path: string[]) {
+    if (!this.data) return;
+    const current = getNodeFromPath(path, this.data);
+    this.activatedGraphs.forEach((g) => g.navigateTo(path, current, this.data));
+  }
+
+  highlightPath(path?: string[] | null) {
+    const current =
+      path && path.length ? getNodeFromPath(path, this.data) : null;
+    this.activatedGraphs.forEach((g) => {
+      if (g.highlightPath) g.highlightPath(path, current, this.data);
+    });
+  }
+
+  navigateUp() {
+    const current = Navigation.currentPath();
+    if (current.length > 1) {
+      current.pop();
+      State.navigateTo(current);
+    }
+  }
+
+  showLess() {
+    this.activatedGraphs.forEach((g) => g.showLess());
+  }
+
+  showMore() {
+    this.activatedGraphs.forEach((g) => g.showMore());
+  }
+
+  cleanup() {
+    this.activatedGraphs.forEach((g) => g.cleanup());
+  }
+
+  activate(graph: any) {
+    this.activatedGraphs.add(graph);
+    if (this.data) {
+      this.data = _loadLast();
+      this.generate(this.data);
+    }
+  }
+
+  loadLast() {
+    const data = _loadLast();
+    if (data) this.generate(data);
+  }
+
+  deactivate(graph: any) {
+    graph.cleanup();
+    this.activatedGraphs.delete(graph);
+  }
+
+  deactivateAll() {
+    this.activatedGraphs.forEach((g) => this.deactivate(g));
+  }
+}
+
+const PluginManager = new SpacePluginManager();
+
+Navigation.on("navigationchanged", (path: string[]) => {
+  PluginManager.navigateTo(path);
+});
+
+// =============================================================================
+// Chart instances
+// =============================================================================
+
+const treemapGraph = TreeMap();
+const sunburstGraph = SunBurst();
+const flamegraphGraph = new FlameGraph();
+const listview = new ListView();
+const breadcrumbs = new Breadcrumbs();
+
+calculateDimensions();
+
+PluginManager.activate(listview);
+PluginManager.activate(breadcrumbs);
+
+// =============================================================================
+// RADAR (main app controller from app/js/radar.js)
+// =============================================================================
+
+let isScanning = false;
+let isPaused = false;
+let current_size = 0;
+let start_time = 0;
+
+let currentDiskInfo: {
+  total: number;
+  used: number;
+  available: number;
+  usePercent: number;
+} | null = null;
+
+const legend = d3Merged.select("#legend");
+const bottomStatus = document.getElementById("bottom_status")!;
+
+function formatNumber(num: number): string {
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+function updateStatsDisplay(
+  fileCount: number,
+  dirCount: number,
+  size: number,
+  errorCount: number,
+) {
+  const elapsed = (performance.now() - start_time) / 1000;
+  const totalItems = fileCount + dirCount;
+  const itemsPerSec = elapsed > 0 ? Math.round(totalItems / elapsed) : 0;
+  const bytesPerSec = elapsed > 0 ? size / elapsed : 0;
+
+  let statusText = `Scanning: ${formatNumber(fileCount)} files | ${formatNumber(dirCount)} dirs | ${format(size)} | ${formatNumber(itemsPerSec)} items/sec | ${format(bytesPerSec)}/sec`;
+
+  if (errorCount && errorCount > 0) {
+    statusText += ` | ${formatNumber(errorCount)} errors`;
+  }
+
+  bottomStatus.textContent = statusText;
+}
+
+function lightbox(show: boolean) {
+  const loading = document.getElementById("loading")!;
+  const shades = document.getElementById("shades")!;
+  const promptbox = document.getElementById("promptbox")!;
+
+  loading.style.display = show ? "block" : "none";
+  shades.style.display = show ? "flex" : "none";
+  promptbox.style.display = show ? "none" : "";
+  shades.style.opacity = show ? "0.8" : "1";
+}
+
+function showPrompt() {
+  const shades = document.getElementById("shades")!;
+  const dir_opener = document.getElementById("dir_opener")!;
+  shades.style.display = "flex";
+  dir_opener.style.display = "none";
+}
+
+function hidePrompt() {
+  const shades = document.getElementById("shades")!;
+  const dir_opener = document.getElementById("dir_opener")!;
+  shades.style.display = "none";
+  dir_opener.style.display = "inline-block";
+}
+
+function updateScanButtons() {
+  const cancelBtn = document.getElementById("cancel_scan_btn");
+  const pauseBtn = document.getElementById("pause_scan_btn");
+
+  if (cancelBtn) {
+    cancelBtn.style.display = isScanning ? "inline-block" : "none";
+  }
+  if (pauseBtn) {
+    pauseBtn.style.display = isScanning ? "inline-block" : "none";
+    if (isScanning) {
+      pauseBtn.textContent = isPaused ? "Resume Scan" : "Pause Scan";
+      pauseBtn.className = isPaused
+        ? "btn btn-positive pull-right"
+        : "btn btn-default pull-right";
+      pauseBtn.onclick = isPaused ? resumeScan : pauseScan;
+    }
+  }
+}
+
+async function startScan(scanPath: string) {
+  cleanup();
+  hidePrompt();
+  State.clearNavigation();
+  legend.style("display", "block");
+  log("start", scanPath);
+  start_time = performance.now();
+  console.time("scan_job_time");
+  isScanning = true;
+  isPaused = false;
+  updateScanButtons();
+
+  // Get disk info via RPC
+  currentDiskInfo = null;
+  try {
+    const diskInfo = await electroview.rpc.request.getDiskInfo({
+      path: scanPath,
+    });
+    if (diskInfo) {
+      currentDiskInfo = diskInfo;
+      const diskSpaceElement = document.getElementById("disk_space_info");
+      if (diskSpaceElement) {
+        const usePercent =
+          diskInfo.usePercent != null ? diskInfo.usePercent.toFixed(2) : "0.00";
+        diskSpaceElement.textContent = `Total: ${format(diskInfo.total)} | Free: ${format(diskInfo.available)} | Used: ${format(diskInfo.used)} (${usePercent}%)`;
+      }
+    }
+  } catch (err) {
+    console.warn("[renderer] Could not get disk info:", err);
+  }
+
+  // Send scan request via RPC
+  try {
+    const result = await electroview.rpc.request.scanDirectory({
+      path: scanPath,
+    });
+    if (!result.started) {
+      console.error("[renderer] Scan failed to start:", result.error);
+      isScanning = false;
+      updateScanButtons();
+    }
+  } catch (err) {
+    console.error("[renderer] Scan request error:", err);
+    isScanning = false;
+    updateScanButtons();
+  }
+}
+
+function progress(
+  dir: string,
+  name: string,
+  size: number,
+  fileCount: number,
+  dirCount: number,
+  errorCount: number,
+) {
+  const pauseBtn = isPaused
+    ? "<button class='btn btn-positive' id='legend-resume-btn' style='margin-top: 10px; margin-right: 5px;'>Resume Scan</button>"
+    : "<button class='btn btn-default' id='legend-pause-btn' style='margin-top: 10px; margin-right: 5px;'>Pause Scan</button>";
+  const statusText = isPaused ? "PAUSED" : "Scanning...";
+
+  legend.html(
+    "<h2>" +
+      statusText +
+      " <i>(try grabbing a drink..)</i></h2>" +
+      "<p style='font-size: 0.8em; word-break: break-all; max-height: 60px; overflow: hidden;'>" +
+      dir +
+      "</p>" +
+      "<br/>Scanned: " +
+      format(size) +
+      (errorCount > 0
+        ? " <span style='color: #c44;'>(" + errorCount + " errors)</span>"
+        : "") +
+      "<br/><br/>" +
+      pauseBtn +
+      "<button class='btn btn-negative' id='legend-cancel-btn' style='margin-top: 10px;'>Cancel Scan</button>",
+  );
+
+  // Wire up legend buttons
+  const legendPauseBtn = document.getElementById("legend-pause-btn");
+  const legendResumeBtn = document.getElementById("legend-resume-btn");
+  const legendCancelBtn = document.getElementById("legend-cancel-btn");
+
+  if (legendPauseBtn) legendPauseBtn.onclick = pauseScan;
+  if (legendResumeBtn) legendResumeBtn.onclick = resumeScan;
+  if (legendCancelBtn) legendCancelBtn.onclick = cancelScan;
+
+  current_size = size;
+
+  if (fileCount !== undefined && dirCount !== undefined) {
+    updateStatsDisplay(fileCount, dirCount, size, errorCount);
+  }
+}
+
+function refresh(json: any) {
+  log("refresh..");
+  lightbox(true);
+  legend.html("Generating preview...");
+
+  setTimeout(() => {
+    onJson(json);
+    lightbox(false);
+  }, 1000);
+}
+
+function cleanup() {
+  lightbox(true);
+  PluginManager.cleanup();
+}
+
+function complete(json: any, finalStats?: any) {
+  log("complete..", json);
+  console.timeEnd("scan_job_time");
+  isScanning = false;
+  isPaused = false;
+  updateScanButtons();
+
+  console.time("a");
+  onJson(json);
+  legend.style("display", "none");
+  lightbox(false);
+  requestAnimationFrame(() => console.timeEnd("a"));
+
+  const time_took = performance.now() - start_time;
+  log("Time took", (time_took / 60 / 1000).toFixed(2), "mins");
+
+  const wasCancelled = finalStats && finalStats.cancelled;
+
+  if (finalStats) {
+    const elapsed = time_took / 1000;
+    const totalItems = finalStats.fileCount + finalStats.dirCount;
+    const itemsPerSec = elapsed > 0 ? Math.round(totalItems / elapsed) : 0;
+    const bytesPerSec = elapsed > 0 ? finalStats.current_size / elapsed : 0;
+    const timeStr =
+      elapsed < 60 ? elapsed.toFixed(1) + "s" : (elapsed / 60).toFixed(1) + "m";
+
+    let statusText = wasCancelled ? "CANCELLED: " : "Scanned: ";
+    statusText += `${formatNumber(finalStats.fileCount)} files | ${formatNumber(finalStats.dirCount)} dirs | ${format(finalStats.current_size)} in ${timeStr} (${formatNumber(itemsPerSec)} items/sec, ${format(bytesPerSec)}/sec)`;
+
+    if (finalStats.errorCount && finalStats.errorCount > 0) {
+      statusText += ` | ${formatNumber(finalStats.errorCount)} errors (permission denied, etc.)`;
+    }
+
+    bottomStatus.textContent = statusText;
+  }
+}
+
+async function cancelScan() {
+  if (!isScanning) return;
+  console.log("[renderer] Cancelling scan...");
+  isPaused = false;
+  legend.html(
+    "<h2>Cancelling scan...</h2><p>Please wait while the scan stops...</p>",
+  );
+  try {
+    await electroview.rpc.request.cancelScan({});
+  } catch (err) {
+    console.error("[renderer] Cancel error:", err);
+  }
+}
+
+async function pauseScan() {
+  if (!isScanning || isPaused) return;
+  console.log("[renderer] Pausing scan...");
+  isPaused = true;
+  updateScanButtons();
+  try {
+    await electroview.rpc.request.pauseScan({});
+  } catch (err) {
+    console.error("[renderer] Pause error:", err);
+  }
+}
+
+async function resumeScan() {
+  if (!isScanning || !isPaused) return;
+  console.log("[renderer] Resuming scan...");
+  isPaused = false;
+  updateScanButtons();
+  try {
+    await electroview.rpc.request.resumeScan({});
+  } catch (err) {
+    console.error("[renderer] Resume error:", err);
+  }
+}
+
+function onJson(data: any) {
+  // Add free space as a child of root if disk info is available
+  if (currentDiskInfo && currentDiskInfo.available > 0) {
+    if (!data.children) data.children = [];
+    data.children = data.children.filter((c: any) => !c._isFreeSpace);
+    data.children.push({
+      name: "Free Space",
+      size: currentDiskInfo.available,
+      _isFreeSpace: true,
+    });
+    console.log("Added free space:", format(currentDiskInfo.available));
+  }
+
+  // Save data via RPC (replaces fs.writeFileSync + zlib)
+  const jsonStr = JSON.stringify(data);
+  electroview.rpc.request.saveScanData({ data: jsonStr }).catch((err: any) => {
+    console.warn("[renderer] Failed to save scan data:", err);
+  });
+
+  PluginManager.generate(data);
+}
+
+function _loadLast(): any {
+  // This is synchronous in the original but must be async with RPC.
+  // For the plugin manager's loadLast, we use an async wrapper.
+  // For the synchronous call in activate(), return cached data.
+  return PluginManager.data;
+}
+
+// Async version of loadLast for initial load
+async function loadLastAsync(): Promise<any> {
+  try {
+    const json = await electroview.rpc.request.loadLastScan({});
+    if (json) {
+      return JSON.parse(json);
+    }
+  } catch (err) {
+    console.warn("[renderer] Failed to load last scan:", err);
+  }
+  return null;
+}
+
+// Override PluginManager.loadLast to be async-aware
+const originalLoadLast = PluginManager.loadLast.bind(PluginManager);
+PluginManager.loadLast = function () {
+  loadLastAsync().then((data) => {
+    if (data) PluginManager.generate(data);
+  });
+};
+
+// =============================================================================
+// VIEW SWITCHING
+// =============================================================================
+
+function hideAll() {
+  [...document.querySelectorAll(".mode_buttons")].forEach((button) =>
+    button.classList.remove("active"),
+  );
+  [...document.querySelectorAll(".graph-container")].forEach(
+    (el) => ((el as HTMLElement).style.display = "none"),
+  );
+}
+
+function deactivateCharts() {
+  [sunburstGraph, treemapGraph, flamegraphGraph].forEach((chart) =>
+    PluginManager.deactivate(chart),
+  );
+}
+
+function showSunburst() {
+  hideAll();
+  document.getElementById("sunburst_button")!.classList.add("active");
+  d3Merged.select("#sunburst-canvas").style("display", "inline-block");
+  d3Merged.select("#sunburst-chart").style("display", "inline-block");
+  deactivateCharts();
+  PluginManager.activate(sunburstGraph);
+}
+
+function showTreemap() {
+  hideAll();
+  document.getElementById("treemap_button")!.classList.add("active");
+  d3Merged.select("canvas").style("display", "inline-block");
+  deactivateCharts();
+  PluginManager.activate(treemapGraph);
+}
+
+function showFlamegraph() {
+  hideAll();
+  document.getElementById("flamegraph_button")!.classList.add("active");
+  document.getElementById("flame-chart")!.style.display = "inline-block";
+  deactivateCharts();
+  PluginManager.activate(flamegraphGraph);
+}
+
+// =============================================================================
+// Actions that use RPC
+// =============================================================================
+
+async function scanFolder() {
+  try {
+    console.log("[renderer] scanFolder invoked");
+    const selectedPath = await electroview.rpc.request.selectFolder({});
+    if (selectedPath) {
+      startScan(selectedPath);
+    } else {
+      console.log("[renderer] Folder selection canceled");
+    }
+  } catch (err) {
+    console.error("[renderer] scanFolder error:", err);
+  }
+}
+
+function scanRoot() {
+  const ok = confirm("This may take some time, continue?");
+  if (ok) {
+    startScan("/");
+  }
+}
+
+async function newWindow() {
+  log("new window");
+  try {
+    await electroview.rpc.request.openNewWindow({});
+  } catch (err) {
+    console.error("[renderer] newWindow error:", err);
+  }
+}
+
+function readFile() {
+  // In Electrobun, we use the folder picker to select a file
+  // (or could add a file picker RPC in the future)
+  scanFolder();
+}
+
+async function scanMemory() {
+  try {
+    const result = await electroview.rpc.request.scanMemory({});
+    if (result) {
+      const data = JSON.parse(result);
+      hidePrompt();
+      onJson(data);
+    }
+  } catch (err) {
+    console.error("[renderer] scanMemory error:", err);
+  }
+}
+
+async function openDirectory() {
+  const loc = Navigation.currentPath();
+  if (loc && loc.length) {
+    try {
+      await electroview.rpc.request.showItemInFolder({ path: loc.join("/") });
+    } catch (err) {
+      console.error("[renderer] openDirectory error:", err);
+    }
+  }
+}
+
+async function openSelection() {
+  if (selection && !selection.children) {
+    const file = key(selection);
+    log("open selection", file);
+    try {
+      await electroview.rpc.request.showItemInFolder({ path: file });
+    } catch (err) {
+      console.error("[renderer] openSelection error:", err);
+    }
+  }
+}
+
+async function showSelection() {
+  if (selection) {
+    const file = key(selection);
+    log("show selection", file);
+    try {
+      await electroview.rpc.request.showItemInFolder({ path: file });
+    } catch (err) {
+      console.error("[renderer] showSelection error:", err);
+    }
+  }
+}
+
+async function trashSelection() {
+  if (selection) {
+    const file = key(selection);
+    const ok = confirm(
+      "Are you sure you wish to send " + file + " to the trash?",
+    );
+    if (ok) {
+      log("trash selection", file);
+      try {
+        const moved = await electroview.rpc.request.moveToTrash({ path: file });
+        if (moved) {
+          alert(
+            file +
+              " moved to trash!\n(currently needs rescan to update graphs)",
+          );
+        }
+      } catch (err) {
+        console.error("[renderer] trashSelection error:", err);
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Drag and Drop
+// =============================================================================
+
+document.ondragover = document.ondrop = (e) => {
+  e.preventDefault();
+  return false;
+};
+
+const promptbox = document.getElementById("promptbox")!;
+promptbox.ondragover = function () {
+  this.className = "hover";
+  return false;
+};
+promptbox.ondragleave = promptbox.ondragend = function () {
+  this.className = "";
+  return false;
+};
+promptbox.ondrop = function (e) {
+  this.className = "";
+  e.preventDefault();
+  const file = e.dataTransfer?.files[0];
+  if (file) {
+    // In WebView, file.path may not be available. Use file.name as fallback.
+    const filePath = (file as any).path || file.name;
+    if (filePath) startScan(filePath);
+  }
+};
+
+// =============================================================================
+// WINDOW RESIZE
+// =============================================================================
+
+d3Merged.select(window).on("resize", () => {
+  PluginManager.resize();
+});
+
+// =============================================================================
+// BUTTON WIRING (replaces inline onclick handlers)
+// =============================================================================
+
+function wireButton(id: string, handler: () => void) {
+  const el = document.getElementById(id);
+  if (el) el.addEventListener("click", handler);
+}
+
+// Toolbar buttons
+wireButton("btn-new-window", newWindow);
+wireButton("btn-scan-root", scanRoot);
+wireButton("btn-scan-folder", scanFolder);
+wireButton("btn-read-file", readFile);
+wireButton("btn-scan-memory", scanMemory);
+wireButton("btn-show-less", () => PluginManager.showLess());
+wireButton("btn-show-more", () => PluginManager.showMore());
+wireButton("btn-navigate-up", () => PluginManager.navigateUp());
+
+// Mode buttons
+wireButton("sunburst_button", showSunburst);
+wireButton("flamegraph_button", showFlamegraph);
+wireButton("treemap_button", showTreemap);
+
+// Footer buttons
+wireButton("btn-nav-back", () => Navigation.back());
+wireButton("btn-nav-forward", () => Navigation.forward());
+wireButton("dir_opener", openDirectory);
+wireButton("cancel_scan_btn", cancelScan);
+wireButton("pause_scan_btn", pauseScan);
+
+// Prompt buttons
+wireButton("prompt-scan-root", scanRoot);
+wireButton("prompt-scan-folder", scanFolder);
+wireButton("prompt-read-file", readFile);
+wireButton("prompt-scan-memory", scanMemory);
+wireButton("prompt-load-last", () => {
+  hidePrompt();
+  State.clearNavigation();
+  PluginManager.loadLast();
+});
+
+// =============================================================================
+// STARTUP
+// =============================================================================
+
+function ready() {
+  showPrompt();
+  showSunburst();
+
+  // Auto-open folder picker on startup
+  try {
+    console.log("[renderer] auto-opening folder picker on startup");
+    scanFolder();
+  } catch (e) {
+    console.error("[renderer] auto-open picker failed", e);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", ready);
+} else {
+  ready();
+}
+
+// =============================================================================
+// Expose key functions on window for debugging / interop
+// =============================================================================
+
+(window as any).scanRoot = scanRoot;
+(window as any).scanFolder = scanFolder;
+(window as any).readFile = readFile;
+(window as any).scanMemory = scanMemory;
+(window as any).newWindow = newWindow;
+(window as any).showSunburst = showSunburst;
+(window as any).showTreemap = showTreemap;
+(window as any).showFlamegraph = showFlamegraph;
+(window as any).openDirectory = openDirectory;
+(window as any).cancelScan = cancelScan;
+(window as any).pauseScan = pauseScan;
+(window as any).resumeScan = resumeScan;
+(window as any).hidePrompt = hidePrompt;
+(window as any).showPrompt = showPrompt;
+(window as any).Navigation = Navigation;
+(window as any).State = State;
+(window as any).PluginManager = PluginManager;
+(window as any).format = format;
+(window as any).log = log;

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -1332,6 +1332,12 @@ function SunBurst() {
       if (innerR < 0) innerR = 0;
       if (outerR <= innerR) return;
 
+      // Skip arcs too small to draw — their angular span is less than the
+      // 0.005-radian gap subtracted below, which would invert startAngle
+      // and endAngle. The hitTest wrap-around logic then matches nearly
+      // every angle, stealing clicks from real arcs.
+      if (d.dx < 0.005) return;
+
       visibleNodes.push({
         data: d,
         startAngle: d.x + ADJUSTMENT,
@@ -3033,10 +3039,7 @@ async function scanFolder() {
 }
 
 function scanRoot() {
-  const ok = confirm("This may take some time, continue?");
-  if (ok) {
-    startScan("/");
-  }
+  startScan("/");
 }
 
 async function newWindow() {

--- a/electrobun/src/mainview/index.ts
+++ b/electrobun/src/mainview/index.ts
@@ -40,6 +40,7 @@ const d3Merged: any = Object.assign(
 // =============================================================================
 
 const rpc = Electroview.defineRPC<SpaceRadarRPC>({
+  maxRequestTime: 300_000, // 5 minutes — must match bun side for long operations like selectFolder
   handlers: {
     requests: {},
     messages: {

--- a/electrobun/src/mainview/style.css
+++ b/electrobun/src/mainview/style.css
@@ -27,12 +27,18 @@ body {
   padding: 0;
   position: relative;
   overflow: hidden;
+  height: 100%;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 13px;
   color: #333;
   background: #fff;
+}
+
+html {
+  height: 100%;
+  overflow: hidden;
 }
 
 /* =============================================================================
@@ -43,8 +49,8 @@ body {
 .window {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
 }
 
 /* Toolbar / Header */
@@ -54,6 +60,7 @@ body {
   border-bottom: 1px solid #c4c4c4;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .toolbar-header {
@@ -85,6 +92,7 @@ body {
   border-top: 1px solid #c4c4c4;
   border-bottom: none;
   min-height: 32px;
+  flex-shrink: 0;
 }
 
 /* Buttons */

--- a/electrobun/src/mainview/style.css
+++ b/electrobun/src/mainview/style.css
@@ -1,0 +1,846 @@
+/**
+ * Space Radar - Electrobun Edition Styles
+ * 
+ * Consolidates:
+ * - app/css/style.css (main styles + dark mode)
+ * - app/css/throbber.css (loading spinner)
+ * - app/css/breadcrumb.css (breadcrumb navigation)
+ * - Subset of PhotonKit CSS (buttons, toolbar, window chrome)
+ * - d3-flamegraph tooltip styles
+ *
+ * Replaces PhotonKit dependency with self-contained CSS.
+ * Uses Electrobun's drag region system instead of -webkit-app-region.
+ */
+
+/* =============================================================================
+   RESET & BASE
+   ============================================================================= */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  position: relative;
+  overflow: hidden;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-size: 13px;
+  color: #333;
+  background: #fff;
+}
+
+/* =============================================================================
+   PHOTONKIT-COMPATIBLE UI COMPONENTS
+   ============================================================================= */
+
+/* Window Chrome */
+.window {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* Toolbar / Header */
+.toolbar {
+  min-height: 36px;
+  padding: 4px 8px;
+  border-bottom: 1px solid #c4c4c4;
+  display: flex;
+  align-items: center;
+}
+
+.toolbar-header {
+  background: linear-gradient(to bottom, #f7f7f7, #e8e8e8);
+  /* Electrobun drag region for title bar */
+}
+
+/* Add drag region class for Electrobun */
+.toolbar-header .title {
+  flex: 0 0 auto;
+  font-size: 13px;
+  font-weight: 500;
+  color: #555;
+  padding: 0 12px;
+  /* On macOS with hiddenInset, leave room for traffic lights */
+  margin-left: 68px;
+  white-space: nowrap;
+}
+
+.toolbar-actions {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.toolbar-footer {
+  background: linear-gradient(to bottom, #f7f7f7, #e8e8e8);
+  border-top: 1px solid #c4c4c4;
+  border-bottom: none;
+  min-height: 32px;
+}
+
+/* Buttons */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  border: 1px solid #b8b8b8;
+  border-radius: 4px;
+  background: linear-gradient(to bottom, #fcfcfc, #e8e8e8);
+  color: #333;
+  cursor: pointer;
+  white-space: nowrap;
+  -webkit-user-select: none;
+  user-select: none;
+  outline: none;
+}
+
+.btn:hover {
+  background: linear-gradient(to bottom, #fff, #efefef);
+}
+
+.btn:active,
+.btn.active {
+  background: linear-gradient(to bottom, #ddd, #e8e8e8);
+  border-color: #999;
+}
+
+.btn-large {
+  padding: 4px 12px;
+  font-size: 13px;
+}
+
+.btn-default {
+}
+
+.btn-primary {
+  background: linear-gradient(to bottom, #6eb4f7, #1a82e2);
+  border-color: #0f6dd3;
+  color: #fff;
+}
+
+.btn-positive {
+  background: linear-gradient(to bottom, #68cd67, #2faa2f);
+  border-color: #28962b;
+  color: #fff;
+}
+
+.btn-negative {
+  background: linear-gradient(to bottom, #e66e5f, #cc3a2a);
+  border-color: #b82e1f;
+  color: #fff;
+}
+
+.btn-warning {
+  background: linear-gradient(to bottom, #f7c948, #e6a817);
+  border-color: #c9920f;
+  color: #333;
+}
+
+/* Button Groups */
+.btn-group {
+  display: inline-flex;
+}
+
+.btn-group .btn {
+  border-radius: 0;
+  margin-left: -1px;
+}
+
+.btn-group .btn:first-child {
+  border-radius: 4px 0 0 4px;
+  margin-left: 0;
+}
+
+.btn-group .btn:last-child {
+  border-radius: 0 4px 4px 0;
+}
+
+/* Pull Right */
+.pull-right {
+  margin-left: auto !important;
+}
+
+/* Window Content */
+.window-content {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: #fff;
+}
+
+/* =============================================================================
+   PHOTONKIT ICONS (subset using Unicode/emoji fallback)
+   ============================================================================= */
+
+.icon {
+  display: inline-block;
+}
+.icon-text {
+  margin-right: 2px;
+}
+.icon-popup::before {
+  content: "⊞";
+}
+.icon-drive::before {
+  content: "💿";
+  font-size: 0.9em;
+}
+.icon-folder::before {
+  content: "📁";
+  font-size: 0.9em;
+}
+.icon-target::before {
+  content: "🎯";
+  font-size: 0.9em;
+}
+.icon-back::before {
+  content: "◀";
+}
+.icon-minus::before {
+  content: "−";
+}
+.icon-plus::before {
+  content: "+";
+}
+.icon-up-circled::before {
+  content: "⬆";
+}
+.icon-cd::before {
+  content: "◉";
+}
+.icon-water::before {
+  content: "≡";
+}
+.icon-layout::before {
+  content: "▦";
+}
+.icon-left-bold::before {
+  content: "◀";
+}
+.icon-right-bold::before {
+  content: "▶";
+}
+.icon-record::before {
+  content: "●";
+  font-size: 0.8em;
+}
+
+/* =============================================================================
+   NAVIGATION & NAV GROUPS (PhotonKit sidebar)
+   ============================================================================= */
+
+.nav-group {
+  padding: 0;
+  margin: 0;
+}
+
+.nav-group-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #666;
+  padding: 6px 12px 2px;
+  margin: 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nav-group-item {
+  display: block;
+  padding: 2px 12px;
+  font-size: 12px;
+  color: #333;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nav-group-item:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.nav-group-item.active {
+  background: #116cd6;
+  color: #fff;
+}
+
+/* =============================================================================
+   APP-SPECIFIC STYLES (from app/css/style.css)
+   ============================================================================= */
+
+#photon-window {
+  z-index: 400;
+}
+
+path {
+  stroke: #fff;
+  fill-rule: evenodd;
+}
+
+circle {
+  pointer-events: all;
+  fill: #eee;
+  opacity: 0.2;
+}
+
+circle:hover {
+  fill: none;
+}
+
+#core:hover {
+  opacity: 0.5;
+  cursor: pointer;
+}
+
+/* Flame graph tooltip */
+.d3-flame-graph-tip {
+  z-index: 1000;
+}
+
+.cell > rect:hover {
+  fill: yellow;
+}
+
+/* Explanation / Center Display */
+#explanation {
+  position: absolute;
+  width: 140px;
+  height: 140px;
+  margin: auto;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  text-align: center;
+  color: #333;
+  z-index: -1;
+  font-weight: 200;
+}
+
+#core_top {
+  font-size: 1.3em;
+}
+
+#core_center {
+  font-size: 2em;
+}
+
+/* Legend */
+#legend {
+  text-align: center;
+  padding-top: 20px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 40px;
+  z-index: 50;
+  background: #ddd;
+  display: none;
+}
+
+#legend h2 {
+  font-size: 1.2em;
+  font-style: inherit;
+  margin: 0;
+  padding: 0;
+}
+
+#legend p {
+  font-size: 0.9em;
+  margin: 0;
+  padding: 0;
+}
+
+/* Loading Overlay */
+#loading {
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  position: fixed;
+  display: inline-block;
+  margin: auto;
+  z-index: 250;
+  width: 100px;
+  height: 100px;
+  display: none;
+}
+
+.area {
+  cursor: pointer;
+}
+
+.area:hover {
+  stroke: #999;
+  stroke-width: 2px;
+  opacity: 1;
+}
+
+/* Flame chart */
+#flame-chart {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  vertical-align: top;
+}
+
+.svg-container {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  vertical-align: top;
+  overflow: hidden;
+}
+
+/* Sunburst canvas styles */
+#sunburst-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
+
+#sunburst-chart {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+#sunburst-chart #explanation {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.svg-content-responsive {
+  display: inline-block;
+  position: absolute;
+}
+
+/* Sequence / Breadcrumbs */
+#sequence {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 100;
+}
+
+#chart {
+  position: relative;
+}
+
+#chart path {
+  stroke: #fff;
+}
+
+/* Sidebar */
+#sidebar {
+  z-index: 100;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 150px;
+  transition: width 0.6s;
+  background: rgba(0, 0, 0, 0.05);
+  max-height: 100%;
+  overflow-y: auto;
+}
+
+#sidebar:hover {
+  width: 400px;
+}
+
+/* Center-aligned Flex Box (Prompt Screen) */
+.Aligner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Aligner-item {
+  max-width: 50%;
+  background: #ddd;
+  opacity: 1;
+  border-radius: 4px;
+}
+
+.Aligner-item--top {
+  align-self: flex-start;
+}
+
+.Aligner-item--bottom {
+  align-self: flex-end;
+}
+
+#shades {
+  z-index: 200;
+  width: 100%;
+  height: 100%;
+  background: #333;
+  position: absolute;
+  display: none;
+}
+
+#promptbox {
+  width: 100%;
+  text-align: center;
+  padding: 20px;
+  height: 200px;
+}
+
+#bottom_status {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+}
+
+#disk_space_info {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Graph containers - hide by default */
+.graph-container {
+  display: none;
+}
+
+/* =============================================================================
+   THROBBER / LOADING ANIMATION (from app/css/throbber.css)
+   ============================================================================= */
+
+@keyframes throbber-loader {
+  0% {
+    background: #dde2e7;
+  }
+  10% {
+    background: #6b9dc8;
+  }
+  40% {
+    background: #dde2e7;
+  }
+}
+
+.throbber-loader:not(:required) {
+  animation: throbber-loader 2000ms 300ms infinite ease-out;
+  background: #dde2e7;
+  display: inline-block;
+  position: relative;
+  text-indent: -9999px;
+  width: 0.9em;
+  height: 1.5em;
+  margin: 0 1.6em;
+}
+
+.throbber-loader:not(:required):before,
+.throbber-loader:not(:required):after {
+  background: #dde2e7;
+  content: "\200B";
+  display: inline-block;
+  width: 0.9em;
+  height: 1.5em;
+  position: absolute;
+  top: 0;
+}
+
+.throbber-loader:not(:required):before {
+  animation: throbber-loader 2000ms 150ms infinite ease-out;
+  left: -1.6em;
+}
+
+.throbber-loader:not(:required):after {
+  animation: throbber-loader 2000ms 450ms infinite ease-out;
+  right: -1.6em;
+}
+
+/* =============================================================================
+   BREADCRUMB NAVIGATION (from app/css/breadcrumb.css)
+   ============================================================================= */
+
+.breadcrumb {
+  display: inline-block;
+  box-shadow: 0 0 15px 1px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  border-radius: 5px;
+  counter-reset: flag;
+}
+
+.breadcrumb a {
+  text-decoration: none;
+  outline: none;
+  display: block;
+  float: left;
+  font-size: 12px;
+  line-height: 28px;
+  color: white;
+  padding: 0 10px 0 30px;
+  background: #666;
+  background: linear-gradient(#666, #333);
+  position: relative;
+}
+
+.breadcrumb a:first-child {
+  padding-left: 46px;
+  border-radius: 5px 0 0 5px;
+}
+
+.breadcrumb a:first-child:before {
+  left: 14px;
+}
+
+.breadcrumb a:last-child {
+  border-radius: 0 5px 5px 0;
+  padding-right: 20px;
+}
+
+.breadcrumb a.active,
+.breadcrumb a:hover {
+  opacity: 0.8;
+}
+
+.breadcrumb a.active:after,
+.breadcrumb a:hover:after {
+  opacity: 0.8;
+}
+
+.breadcrumb a:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -18px;
+  width: 36px;
+  height: 36px;
+  transform: scale(0.707) rotate(45deg);
+  z-index: 1;
+  background: #666;
+  background: linear-gradient(135deg, #666, #333);
+  box-shadow:
+    2px -2px 0 2px rgba(0, 0, 0, 0.4),
+    3px -3px 0 2px rgba(255, 255, 255, 0.1);
+  border-radius: 0 5px 0 50px;
+}
+
+.breadcrumb a:last-child:after {
+  content: none;
+}
+
+.breadcrumb a:before {
+  border-radius: 100%;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  margin: 8px 0;
+  position: absolute;
+  top: 0;
+  left: 30px;
+  background: #444;
+  background: linear-gradient(#444, #222);
+  font-weight: bold;
+}
+
+.flat a,
+.flat a:after {
+  background: inherit;
+  color: black;
+  transition: all 0.5s;
+}
+
+.flat a:before {
+  background: white;
+  box-shadow: 0 0 0 1px #ccc;
+}
+
+/* =============================================================================
+   D3 FLAMEGRAPH STYLES (inlined from d3-flamegraph.css)
+   ============================================================================= */
+
+.d3-flame-graph rect {
+  stroke: #eeeeee;
+  fill-opacity: 0.8;
+}
+
+.d3-flame-graph rect:hover {
+  stroke: #474747;
+  fill-opacity: 1;
+}
+
+.d3-flame-graph-label {
+  pointer-events: none;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  font-size: 12px;
+  font-family: Verdana;
+  margin-left: 4px;
+  margin-right: 4px;
+  line-height: 1.5;
+  padding: 0 0 0;
+  font-weight: 400;
+  color: black;
+  text-align: left;
+}
+
+.d3-flame-graph .fade {
+  opacity: 0.6 !important;
+}
+
+.d3-flame-graph .title {
+  font-size: 20px;
+  font-family: Verdana;
+}
+
+.d3-flame-graph-tip {
+  background-color: black;
+  border: none;
+  border-radius: 3px;
+  padding: 5px 10px 5px 10px;
+  min-height: 18px;
+  font-family: Verdana;
+  font-size: 12px;
+  color: white;
+  position: absolute;
+  z-index: 1000;
+  text-align: center;
+  pointer-events: none;
+}
+
+/* =============================================================================
+   DARK MODE STYLES
+   ============================================================================= */
+
+body.dark-mode {
+  background-color: #1a1a1a;
+  color: #e0e0e0;
+}
+
+body.dark-mode .window {
+  background-color: #1a1a1a;
+}
+
+body.dark-mode .toolbar-header,
+body.dark-mode .toolbar-footer {
+  background: linear-gradient(to bottom, #2d2d2d, #252525);
+  border-color: #3a3a3a;
+}
+
+body.dark-mode .toolbar-header .title {
+  color: #e0e0e0;
+}
+
+body.dark-mode .btn {
+  background: linear-gradient(to bottom, #404040, #353535);
+  border-color: #505050;
+  color: #e0e0e0;
+}
+
+body.dark-mode .btn:hover {
+  background: linear-gradient(to bottom, #4a4a4a, #404040);
+}
+
+body.dark-mode .btn:active,
+body.dark-mode .btn.active {
+  background: linear-gradient(to bottom, #353535, #404040);
+  border-color: #606060;
+}
+
+body.dark-mode .window-content {
+  background-color: #1a1a1a;
+}
+
+body.dark-mode #sidebar {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+body.dark-mode .nav-group-item {
+  color: #ccc;
+}
+
+body.dark-mode .nav-group-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+body.dark-mode .nav-group-item.active {
+  background: #116cd6;
+  color: #fff;
+}
+
+body.dark-mode .nav-group-title {
+  color: #999;
+}
+
+body.dark-mode #legend {
+  background: #2d2d2d;
+  color: #e0e0e0;
+}
+
+body.dark-mode #shades {
+  background: #1a1a1a;
+}
+
+body.dark-mode .Aligner-item {
+  background: #2d2d2d;
+}
+
+body.dark-mode #promptbox {
+  color: #e0e0e0;
+}
+
+body.dark-mode #explanation {
+  color: #ccc;
+}
+
+body.dark-mode path {
+  stroke: rgba(0, 0, 0, 0.4);
+}
+
+body.dark-mode #chart path {
+  stroke: rgba(0, 0, 0, 0.4);
+}
+
+body.dark-mode .breadcrumb {
+  background: #2d2d2d;
+}
+
+body.dark-mode .breadcrumb a {
+  background: #404040;
+  color: #e0e0e0;
+}
+
+body.dark-mode .breadcrumb a:hover {
+  background: #505050;
+}
+
+body.dark-mode #loading {
+  color: #e0e0e0;
+}
+
+body.dark-mode #bottom_status {
+  color: #b0b0b0;
+}
+
+/* Dark mode for flamegraph */
+body.dark-mode .d3-flame-graph rect {
+  stroke: #333;
+}
+
+body.dark-mode .d3-flame-graph-label {
+  color: #ddd;
+}

--- a/electrobun/src/shared/types.ts
+++ b/electrobun/src/shared/types.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared RPC type definitions for Space Radar Electrobun
+ *
+ * Defines the typed contract between the Bun main process and the WebView renderer.
+ * Replaces the 4 separate IPC mechanisms from the Electron version:
+ *   1. Electron ipcMain/ipcRenderer
+ *   2. localStorage cross-window hack
+ *   3. Temp file compressed IPC
+ *   4. webContents.send
+ *
+ * All of these are now unified into Electrobun's typed RPC system.
+ */
+
+export type RPCSchema<T> = T;
+
+export type SpaceRadarRPC = {
+  /** Functions that execute in the Bun main process, callable from the webview */
+  bun: RPCSchema<{
+    requests: {
+      /** Open a native folder picker dialog */
+      selectFolder: {
+        params: {
+          startingFolder?: string;
+        };
+        response: string | null;
+      };
+      /** Start scanning a directory path */
+      scanDirectory: {
+        params: {
+          path: string;
+        };
+        response: { started: boolean; error?: string };
+      };
+      /** Cancel the current scan */
+      cancelScan: {
+        params: {};
+        response: void;
+      };
+      /** Pause the current scan */
+      pauseScan: {
+        params: {};
+        response: void;
+      };
+      /** Resume the current scan */
+      resumeScan: {
+        params: {};
+        response: void;
+      };
+      /** Show a file/folder in the system file manager */
+      showItemInFolder: {
+        params: {
+          path: string;
+        };
+        response: void;
+      };
+      /** Move a file/folder to the system trash */
+      moveToTrash: {
+        params: {
+          path: string;
+        };
+        response: boolean;
+      };
+      /** Open a new app window */
+      openNewWindow: {
+        params: {};
+        response: void;
+      };
+      /** Get disk space info for a path */
+      getDiskInfo: {
+        params: {
+          path: string;
+        };
+        response: {
+          total: number;
+          used: number;
+          available: number;
+          usePercent: number;
+        } | null;
+      };
+      /** Load last saved scan data */
+      loadLastScan: {
+        params: {};
+        response: string | null; // JSON string of tree data
+      };
+      /** Save scan data for persistence */
+      saveScanData: {
+        params: {
+          data: string; // JSON string of tree data
+        };
+        response: void;
+      };
+      /** Show a native context menu */
+      showContextMenu: {
+        params: {
+          items: Array<{
+            label: string;
+            action: string;
+            enabled?: boolean;
+          }>;
+        };
+        response: void;
+      };
+      /** Scan memory usage (process tree) */
+      scanMemory: {
+        params: {};
+        response: string | null; // JSON string of memory tree
+      };
+    };
+    messages: {
+      /** Generic log message from webview to bun */
+      logToBun: {
+        msg: string;
+      };
+    };
+  }>;
+  /** Functions that execute in the WebView, callable from Bun */
+  webview: RPCSchema<{
+    requests: {};
+    messages: {
+      /** Scan progress update */
+      scanProgress: {
+        dir: string;
+        name: string;
+        size: number;
+        fileCount: number;
+        dirCount: number;
+        errorCount: number;
+      };
+      /** Scan refresh (intermediate preview of data) */
+      scanRefresh: {
+        data: string; // JSON tree data
+      };
+      /** Scan completed */
+      scanComplete: {
+        data: string; // JSON tree data
+        stats: {
+          fileCount: number;
+          dirCount: number;
+          currentSize: number;
+          errorCount: number;
+          cancelled: boolean;
+        };
+      };
+      /** Scan error */
+      scanError: {
+        error: string;
+      };
+      /** Color/mode change from application menu */
+      colorChange: {
+        type: string;
+        value: string;
+      };
+      /** Context menu item clicked */
+      contextMenuClicked: {
+        action: string;
+      };
+    };
+  }>;
+};

--- a/electrobun/src/shared/types.ts
+++ b/electrobun/src/shared/types.ts
@@ -89,6 +89,11 @@ export type SpaceRadarRPC = {
         };
         response: void;
       };
+      /** Load the in-progress scan preview from temp file */
+      loadScanPreview: {
+        params: {};
+        response: string | null; // JSON string of tree data
+      };
       /** Show a native context menu */
       showContextMenu: {
         params: {
@@ -126,13 +131,10 @@ export type SpaceRadarRPC = {
         dirCount: number;
         errorCount: number;
       };
-      /** Scan refresh (intermediate preview of data) */
-      scanRefresh: {
-        data: string; // JSON tree data
-      };
-      /** Scan completed */
+      /** Scan refresh — tree data flushed to file, webview should pull it */
+      scanRefresh: {};
+      /** Scan completed — tree data flushed to file, webview should pull it */
       scanComplete: {
-        data: string; // JSON tree data
         stats: {
           fileCount: number;
           dirCount: number;

--- a/electrobun/src/shared/types.ts
+++ b/electrobun/src/shared/types.ts
@@ -94,6 +94,27 @@ export type SpaceRadarRPC = {
         params: {};
         response: string | null; // JSON string of tree data
       };
+      /** Get a depth-limited subtree from the SQLite scan DB.
+       *  Each node includes _nodeId for drill-down navigation. */
+      getSubtree: {
+        params: {
+          nodeId: number;
+          depth: number;
+        };
+        response: string | null; // JSON string of partial tree
+      };
+      /** Get the root node ID of the current/last scan. */
+      getScanRootId: {
+        params: {};
+        response: number | null;
+      };
+      /** Get the full filesystem path for a node (for breadcrumbs, Finder). */
+      getNodePath: {
+        params: {
+          nodeId: number;
+        };
+        response: string | null;
+      };
       /** Show a native context menu */
       showContextMenu: {
         params: {

--- a/electrobun/tsconfig.json
+++ b/electrobun/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "space-radar",
   "productName": "SpaceRadar",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Disk Usage Electron App",
   "main": "app/main.js",
   "scripts": {
@@ -73,13 +73,6 @@
             "x64",
             "arm64"
           ]
-        },
-        {
-          "target": "zip",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
         }
       ],
       "hardenedRuntime": true,
@@ -106,12 +99,6 @@
           "arch": [
             "x64"
           ]
-        },
-        {
-          "target": "zip",
-          "arch": [
-            "x64"
-          ]
         }
       ],
       "icon": "Icon.png"
@@ -126,18 +113,6 @@
       "target": [
         {
           "target": "AppImage",
-          "arch": [
-            "x64"
-          ]
-        },
-        {
-          "target": "deb",
-          "arch": [
-            "x64"
-          ]
-        },
-        {
-          "target": "zip",
           "arch": [
             "x64"
           ]


### PR DESCRIPTION
Migration from Electron -> Electrobun

<img width="1312" height="912" alt="SCR-20260221-btuc" src="https://github.com/user-attachments/assets/df139aa0-fd18-42f2-94cd-d21044aaa8f9" />
<img width="1312" height="912" alt="SCR-20260221-btzp" src="https://github.com/user-attachments/assets/fbc51a56-594b-45a9-aea3-b5856d27a873" />


- Faster
- Less disk usage Fixes #66 
- Less memory usage (due to migration to bun's sqlite) Fixes #39

Notes:
- With the new changes in Electrobun, I takes less than 2 minutes to complete my diskscan, while keeping under memory usage <1GB. The current Electron version takes about 2GB (due to rendering the 2 million files I've scanned)
- After this merge, both the classic electron and new electronbun should be built
- This is a transitionary phase such that Electron get the most updates while ElectronBun gets feature parity